### PR TITLE
Build fixes for Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19.1</version>
         <configuration>
-          <forkCount>3</forkCount>
-          <reuseForks>true</reuseForks>
-          <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+          <forkMode>always</forkMode>
+          <argLine>-Xmx1024m</argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -92,6 +91,9 @@
             <goals>
               <goal>jar</goal>
             </goals>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
I'm on Mac OS, java 8:

```
$ java -version
java version "1.8.0_91"
Java(TM) SE Runtime Environment (build 1.8.0_91-b14)
Java HotSpot(TM) 64-Bit Server VM (build 25.91-b14, mixed mode)
```

I had to make the above changes to get the build to work correctly.

```
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
```

Also, DocLint in Java 8 barfs the entire build on warnings, which is silly, see:
http://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete
