### PR TITLE
Interfaces for monopartite directed graphs

### DIFF
--- a/src/main/java/com/twitter/graphjet/directed/api/DirectedGraph.java
+++ b/src/main/java/com/twitter/graphjet/directed/api/DirectedGraph.java
@@ -17,11 +17,11 @@
 package com.twitter.graphjet.directed.api;
 
 /**
- * <p>Interface that specifies all the read operations needed for a monopartite directed graph. In particular,
- * any graph manipulations or graph algorithms should only need to use this interface.</p>
+ * <p>Interface that specifies all the read operations needed for a directed graph. In particular, any graph
+ * manipulations or graph algorithms should only need to use this interface.</p>
  *
- * <p>All operations are defined in {@link OutgoingIndexedDirectedGraph} and {@link IncomingIndexedDirectedGraph}. This
- * interface serves as a convenience wrapper that is used to refer to a bi-indexed monopartite directed graph.</p>
+ * <p>All operations are defined in {@link OutIndexedDirectedGraph} and {@link InIndexedDirectedGraph}. This
+ * interface serves as a convenience wrapper that is used to refer to a bi-indexed directed graph.</p>
  *
  * <p>Notes:</p>
  *
@@ -35,5 +35,5 @@ package com.twitter.graphjet.directed.api;
  *
  * </ul>
  */
-public interface DirectedGraph extends OutgoingIndexedDirectedGraph, IncomingIndexedDirectedGraph {
+public interface DirectedGraph extends OutIndexedDirectedGraph, InIndexedDirectedGraph {
 }

--- a/src/main/java/com/twitter/graphjet/directed/api/DynamicDirectedGraph.java
+++ b/src/main/java/com/twitter/graphjet/directed/api/DynamicDirectedGraph.java
@@ -17,8 +17,7 @@
 package com.twitter.graphjet.directed.api;
 
 /**
- * <p>Interface that specifies all the write operations needed for a dynamically updating monopartite directed
- * graph.</p>
+ * <p>Interface that specifies all the write operations needed for a dynamically updating directed graph.</p>
  *
  * <p>Notes:</p>
  *

--- a/src/main/java/com/twitter/graphjet/directed/api/InIndexedDirectedGraph.java
+++ b/src/main/java/com/twitter/graphjet/directed/api/InIndexedDirectedGraph.java
@@ -16,15 +16,15 @@
 
 package com.twitter.graphjet.directed.api;
 
-import java.util.Random;
 import com.twitter.graphjet.bipartite.api.EdgeIterator;
-import javax.annotation.Nullable;
 
+import javax.annotation.Nullable;
+import java.util.Random;
 
 /**
- * <p>Interface that specifies all the read operations needed for a monopartite directed graph indexed by incoming
- * edges. In particular, any graph manipulations or graph algorithms that solely access incoming edges should only need
- * to use this interface.</p>
+ * <p>Interface that specifies all the read operations needed for a directed graph indexed by incoming edges. In
+ * particular, any graph manipulations or graph algorithms that solely access incoming edges should only need to use
+ * this interface.</p>
  *
  * <p>Notes:</p>
  *
@@ -38,14 +38,14 @@ import javax.annotation.Nullable;
  *
  * </ul>
  */
-public interface IncomingIndexedDirectedGraph {
+public interface InIndexedDirectedGraph {
   /**
    * Returns the incoming degree of a node. This operation is expected to take O(1).
    *
    * @param node the query node
    * @return the incoming degree of the query node
    */
-  int getIncomingDegree(long node);
+  int getInDegree(long node);
 
   /**
    * Returns all incoming edges of a node. This operation can take O(n) so it should be used sparingly. Note that
@@ -55,7 +55,7 @@ public interface IncomingIndexedDirectedGraph {
    * @return iterator over the incoming edges of the query node, or null if the query node does not exist in the graph
    */
   @Nullable
-  EdgeIterator getIncomingEdges(long node);
+  EdgeIterator getInEdges(long node);
 
   /**
    * Returns a sample of incoming edges of a node. This operation is expected to take O(numSamples). Note that this is
@@ -67,5 +67,5 @@ public interface IncomingIndexedDirectedGraph {
    * in the graph
    */
   @Nullable
-  EdgeIterator getRandomIncomingEdges(long node, int numSamples, Random random);
+  EdgeIterator getRandomInEdges(long node, int numSamples, Random random);
 }

--- a/src/main/java/com/twitter/graphjet/directed/api/OutIndexedDirectedGraph.java
+++ b/src/main/java/com/twitter/graphjet/directed/api/OutIndexedDirectedGraph.java
@@ -16,16 +16,15 @@
 
 package com.twitter.graphjet.directed.api;
 
-import java.util.Random;
-
 import com.twitter.graphjet.bipartite.api.EdgeIterator;
 
 import javax.annotation.Nullable;
+import java.util.Random;
 
 /**
- * <p>Interface that specifies all the read operations needed for a monopartite directed graph indexed by outgoing
- * edges. In particular, any graph manipulations or graph algorithms that solely access outgoing edges should only need
- * to use this interface.</p>
+ * <p>Interface that specifies all the read operations needed for a directed graph indexed by outgoing edges. In
+ * particular, any graph manipulations or graph algorithms that solely access outgoing edges should only need to use
+ * this interface.</p>
  *
  * <p>Notes:</p>
  *
@@ -39,14 +38,14 @@ import javax.annotation.Nullable;
  *
  * </ul>
  */
-public interface OutgoingIndexedDirectedGraph {
+public interface OutIndexedDirectedGraph {
   /**
    * Returns the outgoing degree of a node. This operation is expected to take O(1).
    *
    * @param node the query node
    * @return the outgoing degree of the query node
    */
-  int getOutgoingDegree(long node);
+  int getOutDegree(long node);
 
   /**
    * Returns all outgoing edges of a node. This operation can take O(n) so it should be used sparingly. Note that
@@ -56,7 +55,7 @@ public interface OutgoingIndexedDirectedGraph {
    * @return iterator over the outgoing edges of the query node, or null if the query node does not exist in the graph
    */
   @Nullable
-  EdgeIterator getOutgoingEdges(long node);
+  EdgeIterator getOutEdges(long node);
 
   /**
    * Returns a sample of outgoing edges of a node. This operation is expected to take O(numSamples). Note that this is
@@ -68,5 +67,5 @@ public interface OutgoingIndexedDirectedGraph {
    * in the graph
    */
   @Nullable
-  EdgeIterator getRandomOutgoingEdges(long node, int numSamples, Random random);
+  EdgeIterator getRandomOutEdges(long node, int numSamples, Random random);
 }


### PR DESCRIPTION
Setting up the appropriate interfaces for monpartite directed graphs. Interfaces mirror the basic structure of the bipartite interfaces.
