### PR TITLE
fix the memory leak when client sets maxResults as Integer.MAX_VALUE

### DIFF
--- a/graphjet-core/pom.xml
+++ b/graphjet-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
   </parent>
 
   <groupId>com.twitter</groupId>

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/RecommendationRequest.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/RecommendationRequest.java
@@ -27,6 +27,7 @@ public abstract class RecommendationRequest {
   private final LongSet toBeFiltered;
   private final byte[] socialProofTypes;
   public static final int MAX_RECOMMENDATION_RESULTS = 1000;
+  public static final int DEFAULT_RECOMMENDATION_RESULTS = 100;
 
   protected RecommendationRequest(
     long queryNode,

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/RecommendationRequest.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/RecommendationRequest.java
@@ -26,6 +26,7 @@ public abstract class RecommendationRequest {
   private final long queryNode;
   private final LongSet toBeFiltered;
   private final byte[] socialProofTypes;
+  public static final int MAX_RECOMMENDATION_RESULTS = 1000;
 
   protected RecommendationRequest(
     long queryNode,

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTweetMetadataRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTweetMetadataRecsGenerator.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import com.twitter.graphjet.algorithms.NodeInfo;
 import com.twitter.graphjet.algorithms.RecommendationInfo;
+import com.twitter.graphjet.algorithms.RecommendationRequest;
 import com.twitter.graphjet.algorithms.RecommendationType;
 import com.twitter.graphjet.algorithms.TweetIDMask;
 import com.twitter.graphjet.algorithms.TweetMetadataRecommendationInfo;
@@ -128,7 +129,9 @@ public final class TopSecondDegreeByCountTweetMetadataRecsGenerator {
           : MIN_USER_SOCIAL_PROOF_SIZE;
 
       int maxNumResults = request.getMaxNumResultsByType().containsKey(recommendationType)
-        ? request.getMaxNumResultsByType().get(recommendationType) : Integer.MAX_VALUE;
+        ? Math.min(request.getMaxNumResultsByType().get(recommendationType),
+                   RecommendationRequest.MAX_RECOMMENDATION_RESULTS)
+        : RecommendationRequest.MAX_RECOMMENDATION_RESULTS;
 
       for (Int2ObjectMap.Entry<TweetMetadataRecommendationInfo> entry
         : visitedMetadata.int2ObjectEntrySet()) {

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTweetMetadataRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTweetMetadataRecsGenerator.java
@@ -131,7 +131,7 @@ public final class TopSecondDegreeByCountTweetMetadataRecsGenerator {
       int maxNumResults = request.getMaxNumResultsByType().containsKey(recommendationType)
         ? Math.min(request.getMaxNumResultsByType().get(recommendationType),
                    RecommendationRequest.MAX_RECOMMENDATION_RESULTS)
-        : RecommendationRequest.MAX_RECOMMENDATION_RESULTS;
+        : RecommendationRequest.DEFAULT_RECOMMENDATION_RESULTS;
 
       for (Int2ObjectMap.Entry<TweetMetadataRecommendationInfo> entry
         : visitedMetadata.int2ObjectEntrySet()) {

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Lists;
 
 import com.twitter.graphjet.algorithms.NodeInfo;
 import com.twitter.graphjet.algorithms.RecommendationInfo;
+import com.twitter.graphjet.algorithms.RecommendationRequest;
 import com.twitter.graphjet.algorithms.RecommendationType;
 import com.twitter.graphjet.algorithms.TweetIDMask;
 import com.twitter.graphjet.algorithms.TweetRecommendationInfo;
@@ -120,7 +121,9 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
     List<NodeInfo> nodeInfoList
   ) {
     int maxNumResults = request.getMaxNumResultsByType().containsKey(RecommendationType.TWEET)
-      ? request.getMaxNumResultsByType().get(RecommendationType.TWEET) : Integer.MAX_VALUE;
+      ? Math.min(request.getMaxNumResultsByType().get(RecommendationType.TWEET),
+                 RecommendationRequest.MAX_RECOMMENDATION_RESULTS)
+      : RecommendationRequest.MAX_RECOMMENDATION_RESULTS;
 
     PriorityQueue<NodeInfo> topResults = new PriorityQueue<NodeInfo>(maxNumResults);
 

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -123,7 +123,7 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
     int maxNumResults = request.getMaxNumResultsByType().containsKey(RecommendationType.TWEET)
       ? Math.min(request.getMaxNumResultsByType().get(RecommendationType.TWEET),
                  RecommendationRequest.MAX_RECOMMENDATION_RESULTS)
-      : RecommendationRequest.MAX_RECOMMENDATION_RESULTS;
+      : RecommendationRequest.DEFAULT_RECOMMENDATION_RESULTS;
 
     PriorityQueue<NodeInfo> topResults = new PriorityQueue<NodeInfo>(maxNumResults);
 

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/intersection/IntersectionSimilarity.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/intersection/IntersectionSimilarity.java
@@ -24,6 +24,7 @@ import java.util.Random;
 
 import com.google.common.collect.Lists;
 
+import com.twitter.graphjet.algorithms.RecommendationRequest;
 import com.twitter.graphjet.algorithms.SimilarityAlgorithm;
 import com.twitter.graphjet.algorithms.SimilarityInfo;
 import com.twitter.graphjet.algorithms.SimilarityResponse;
@@ -153,8 +154,11 @@ public class IntersectionSimilarity implements
       }
     }
     // finally, normalize and select top neighbors
-    PriorityQueue<SimilarityInfo> topResults = new PriorityQueue<SimilarityInfo>(
-        request.getMaxNumResults());
+    int maxNumResults = Math.min(
+      request.getMaxNumResults(),
+      RecommendationRequest.MAX_RECOMMENDATION_RESULTS
+    );
+    PriorityQueue<SimilarityInfo> topResults = new PriorityQueue<SimilarityInfo>(maxNumResults);
     for (long similarNode : nodeToWeightedCooccurenceCountsMap.keySet()) {
       double cooccurrence = nodeToWeightedCooccurenceCountsMap.get(similarNode);
       int rawCooccurrence = nodeToCooccurrenceCountsMap.get(similarNode);
@@ -167,7 +171,7 @@ public class IntersectionSimilarity implements
           cooccurrence, similarNodeDegree, queryNodeDegree);
       normWeight = Double.isInfinite(normWeight) ? 0 : normWeight;
       double score = cooccurrence * normWeight;
-      if (topResults.size() < request.getMaxNumResults()) {
+      if (topResults.size() < maxNumResults) {
         topResults.add(new SimilarityInfo(similarNode, score, rawCooccurrence, similarNodeDegree));
       } else if (score > topResults.peek().getWeight()) {
         topResults.poll();

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/randommultigraphneighbors/RandomMultiGraphNeighbors.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/randommultigraphneighbors/RandomMultiGraphNeighbors.java
@@ -24,6 +24,7 @@ import java.util.Random;
 
 import com.google.common.collect.Lists;
 
+import com.twitter.graphjet.algorithms.RecommendationRequest;
 import com.twitter.graphjet.algorithms.filters.RelatedTweetFilterChain;
 import com.twitter.graphjet.bipartite.api.BipartiteGraph;
 import com.twitter.graphjet.bipartite.api.EdgeIterator;
@@ -90,7 +91,10 @@ public class RandomMultiGraphNeighbors {
       RelatedTweetFilterChain filterChain) {
     Long2DoubleMap leftSeedNodeWithWeights = request.getLeftSeedNodesWithWeight();
     int maxNumSamples = request.getMaxNumSamples();
-    int maxNumResults = request.getMaxNumResults();
+    int maxNumResults = Math.min(
+      request.getMaxNumResults(),
+      RecommendationRequest.MAX_RECOMMENDATION_RESULTS
+    );
 
     // construct a IndexArray and AliasTableArray to sample from LHS seed nodes
     long[] indexArray = new long[leftSeedNodeWithWeights.size()];


### PR DESCRIPTION
When a client specifies the number of results to return in the request, if it sets the value to Integer.MAX_VALUE or it does not set the value, GraphJet library will try to initialize the priority queue to size Integer.MAX_VALUE. This causes JVM to throw an exception and kill the service. This rb tries to fix the issue.