### PR TITLE
Gtang/userusergraph

### DIFF
--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/RecommendationRequest.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/RecommendationRequest.java
@@ -28,6 +28,7 @@ public abstract class RecommendationRequest {
   private final byte[] socialProofTypes;
   public static final int MAX_RECOMMENDATION_RESULTS = 1000;
   public static final int DEFAULT_RECOMMENDATION_RESULTS = 100;
+  public static final int DEFAULT_MIN_USER_SOCIAL_PROOF_SIZE = 1;
 
   protected RecommendationRequest(
     long queryNode,

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/RecommendationType.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/RecommendationType.java
@@ -21,8 +21,8 @@ public enum RecommendationType {
   HASHTAG(0),       // hashtag metadata type
   URL(1),           // url metadata type
   METADATASIZE(2),  // the size of supported metadata types
-  TWEET(3);         // tweet, not a metadata type
-
+  TWEET(3),         // tweet, not a metadata type
+  USER(4);          // users, in follows, mentions & mediatags
   private final int value;
 
   private RecommendationType(int value) {

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/UserRecommendationInfo.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/UserRecommendationInfo.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2016 Twitter. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.graphjet.algorithms;
+
+import java.util.Map;
+
+import com.google.common.base.Objects;
+import it.unimi.dsi.fastutil.longs.LongList;
+
+public class UserRecommendationInfo implements RecommendationInfo {
+    private final long recommendation;
+    private final RecommendationType recommendationType;
+    private final double weight;
+    private final Map<Byte, LongList> socialProof;
+
+    public UserRecommendationInfo(long recommendation, double weight, Map<Byte, LongList> socialProof) {
+        this.recommendation = recommendation;
+        this.recommendationType = RecommendationType.USER;
+        this.weight = weight;
+        this.socialProof = socialProof;
+    }
+
+    public long getRecommendation() {
+        return recommendation;
+    }
+
+    public RecommendationType getRecommendationType() {
+        return recommendationType;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    public Map<Byte, LongList> getSocialProof() {
+        return socialProof;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(recommendation, recommendationType, weight, socialProof);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+
+        TweetRecommendationInfo other = (TweetRecommendationInfo) obj;
+
+        return Objects.equal(getRecommendation(), other.getRecommendation())
+            && Objects.equal(getRecommendationType(), other.getRecommendationType())
+            && Objects.equal(getWeight(), other.getWeight())
+            && Objects.equal(getSocialProof(), other.getSocialProof());
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+            .add("recommendation", recommendation)
+            .add("recommendationType", recommendationType)
+            .add("weight", weight)
+            .add("socialProof", socialProof)
+            .toString();
+    }
+}

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/UserRecommendationInfo.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/UserRecommendationInfo.java
@@ -21,6 +21,9 @@ import java.util.Map;
 import com.google.common.base.Objects;
 import it.unimi.dsi.fastutil.longs.LongList;
 
+/**
+ * This class specifies user recommendations based on user follow, mention, and mediatag
+ */
 public class UserRecommendationInfo implements RecommendationInfo {
     private final long recommendation;
     private final RecommendationType recommendationType;

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/GeneratorUtils.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/GeneratorUtils.java
@@ -1,0 +1,81 @@
+package com.twitter.graphjet.algorithms.counting;
+
+import com.twitter.graphjet.algorithms.NodeInfo;
+import com.twitter.graphjet.hashing.SmallArrayBasedLongToDoubleMap;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+/**
+ * Shared utility functions among RecsGenerators
+ */
+public class GeneratorUtils {
+    /**
+     * Pick the top social proofs for each RHS node
+     */
+    public static Map<Byte, LongList> pickTopSocialProofs(
+            SmallArrayBasedLongToDoubleMap[] socialProofs,
+            byte[] validSocialProofs,
+            int maxSocialProofSize
+    ) {
+        Map<Byte, LongList> results = new HashMap<Byte, LongList>();
+        int length = validSocialProofs.length;
+
+        for (int i = 0; i < length; i++) {
+            SmallArrayBasedLongToDoubleMap socialProof = socialProofs[validSocialProofs[i]];
+            if (socialProof != null) {
+                if (socialProof.size() > 1) {
+                    socialProof.sort();
+                }
+
+                socialProof.trim(maxSocialProofSize);
+                results.put(validSocialProofs[i], new LongArrayList(socialProof.keys()));
+            }
+        }
+        return results;
+    }
+
+    public static void addResultToPriorityQueue(
+            PriorityQueue<NodeInfo> topResults,
+            NodeInfo nodeInfo,
+            int maxNumResults
+    ) {
+        if (topResults.size() < maxNumResults) {
+            topResults.add(nodeInfo);
+        } else if (nodeInfo.getWeight() > topResults.peek().getWeight()) {
+            topResults.poll();
+            topResults.add(nodeInfo);
+        }
+    }
+
+    public static boolean isTweetSocialProofOnly(
+            SmallArrayBasedLongToDoubleMap[] socialProofs,
+            int tweetSocialProofType
+    ) {
+        boolean keep = false;
+        for (int i = 0; i < socialProofs.length; i++) {
+            if (i != tweetSocialProofType && socialProofs[i] != null) {
+                keep = true;
+                break;
+            }
+        }
+        return !keep;
+    }
+
+    public static boolean isLessThantMinUserSocialProofSize(
+            SmallArrayBasedLongToDoubleMap[] socialProofs,
+            int minUserSocialProofSize
+    ) {
+        boolean keep = false;
+        for (int i = 0; i < socialProofs.length; i++) {
+            if (socialProofs[i] != null && socialProofs[i].size() >= minUserSocialProofSize) {
+                keep = true;
+                break;
+            }
+        }
+        return !keep;
+    }
+}

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCount.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCount.java
@@ -204,6 +204,7 @@ public class TopSecondDegreeByCount implements
     int numTweetResults = 0;
     int numHashtagResults = 0;
     int numUrlResults = 0;
+    int numUserResults = 0;
     List<RecommendationInfo> recommendations = new ArrayList<RecommendationInfo>();
 
     if (request.getRecommendationTypes().contains(RecommendationType.TWEET)) {
@@ -238,6 +239,16 @@ public class TopSecondDegreeByCount implements
       recommendations.addAll(urlRecommendations);
     }
 
+    if (request.getRecommendationTypes().contains(RecommendationType.USER)) {
+      List<RecommendationInfo> userRecommendations =
+        TopSecondDegreeByCountUserRecsGenerator.generateUserRecs(
+          request,
+          nodeInfosAfterFiltering
+        );
+      numUserResults = userRecommendations.size();
+      recommendations.addAll(userRecommendations);
+    }
+
     LOG.info("TopSecondDegreeByCount: after running algorithm for request_id = "
         + request.getQueryNode()
         + ", we get numDirectNeighbors = "
@@ -258,8 +269,10 @@ public class TopSecondDegreeByCount implements
         + numHashtagResults
         + ", numUrlResults = "
         + numUrlResults
+        + ", numUserResults = "
+        + numUserResults
         + ", totalResults = "
-        + (numTweetResults + numHashtagResults + numUrlResults)
+        + (numTweetResults + numHashtagResults + numUrlResults + numUserResults)
     );
 
     return new TopSecondDegreeByCountResponse(recommendations, topSecondDegreeByCountStats);

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountRequest.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountRequest.java
@@ -79,6 +79,45 @@ public class TopSecondDegreeByCountRequest extends RecommendationRequest {
     this.resultFilterChain = resultFilterChain;
   }
 
+  /**
+   * Request constructor for TopSecondDegreeByCount. This constructor neglects maxTweetSocialProofSize,
+   * as it is only dedicated to user recommendation requests.
+   * @param queryNode                 User Id of the requester
+   * @param leftSeedNodesWithWeight   Weighted seed users
+   * @param toBeFiltered              Excluded User Ids
+   * @param recommendationTypes       Type of recommendation, aka "User" recommendation
+   * @param maxNumResultsByType       Maximum number of results per recommendation type
+   * @param maxSocialProofTypeSize    Number of social proof types
+   * @param maxUserSocialProofSize    Maximum number of users used as social proof. Used to limit network traffic
+   * @param minUserSocialProofSizes   Minimum number of users used as social proof. Used to guarantee social proof quality
+   * @param socialProofTypes          Social proof types, masked into a byte array. Types can be Follow, Mention, & Mediatag
+   * @param resultFilterChain         Filter chain to be applied after recommendation computation
+   */
+  public TopSecondDegreeByCountRequest(
+    long queryNode,
+    Long2DoubleMap leftSeedNodesWithWeight,
+    LongSet toBeFiltered,
+    Set<RecommendationType> recommendationTypes,
+    Map<RecommendationType, Integer> maxNumResultsByType,
+    int maxSocialProofTypeSize,
+    int maxUserSocialProofSize,
+    Map<RecommendationType, Integer> minUserSocialProofSizes,
+    byte[] socialProofTypes,
+    ResultFilterChain resultFilterChain
+  ) {
+    super(queryNode, toBeFiltered, socialProofTypes);
+    this.leftSeedNodesWithWeight = leftSeedNodesWithWeight;
+    this.recommendationTypes = recommendationTypes;
+    this.maxNumResultsByType = maxNumResultsByType;
+    this.maxSocialProofTypeSize = maxSocialProofTypeSize;
+    this.maxUserSocialProofSize = maxUserSocialProofSize;
+    this.minUserSocialProofSizes = minUserSocialProofSizes;
+    this.resultFilterChain = resultFilterChain;
+
+    // This constructor is dedicated to user recommendations, tweets are irrelevant
+    this.maxTweetSocialProofSize = 0;
+  }
+
   public Long2DoubleMap getLeftSeedNodesWithWeight() {
     return leftSeedNodesWithWeight;
   }

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -18,9 +18,7 @@
 package com.twitter.graphjet.algorithms.counting;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.PriorityQueue;
 
 import com.google.common.collect.Lists;
@@ -31,84 +29,8 @@ import com.twitter.graphjet.algorithms.RecommendationRequest;
 import com.twitter.graphjet.algorithms.RecommendationType;
 import com.twitter.graphjet.algorithms.TweetIDMask;
 import com.twitter.graphjet.algorithms.TweetRecommendationInfo;
-import com.twitter.graphjet.hashing.SmallArrayBasedLongToDoubleMap;
-
-import it.unimi.dsi.fastutil.longs.LongArrayList;
-import it.unimi.dsi.fastutil.longs.LongList;
 
 public final class TopSecondDegreeByCountTweetRecsGenerator {
-  private static final int MIN_USER_SOCIAL_PROOF_SIZE = 1;
-
-  private TopSecondDegreeByCountTweetRecsGenerator() {
-  }
-  /**
-   * Pick the top social proofs for each RHS node
-   */
-  private static Map<Byte, LongList> pickTopSocialProofs(
-    SmallArrayBasedLongToDoubleMap[] socialProofs,
-    byte[] validSocialProofs,
-    int maxSocialProofSize
-  ) {
-    Map<Byte, LongList> results = new HashMap<Byte, LongList>();
-    int length = validSocialProofs.length;
-
-    for (int i = 0; i < length; i++) {
-      SmallArrayBasedLongToDoubleMap socialProof = socialProofs[validSocialProofs[i]];
-      if (socialProof != null) {
-        if (socialProof.size() > 1) {
-          socialProof.sort();
-        }
-
-        socialProof.trim(maxSocialProofSize);
-        results.put(validSocialProofs[i], new LongArrayList(socialProof.keys()));
-      }
-    }
-    return results;
-  }
-
-  private static void addResultToPriorityQueue(
-    PriorityQueue<NodeInfo> topResults,
-    NodeInfo nodeInfo,
-    int maxNumResults
-  ) {
-    if (topResults.size() < maxNumResults) {
-      topResults.add(nodeInfo);
-    } else if (nodeInfo.getWeight() > topResults.peek().getWeight()) {
-      topResults.poll();
-      topResults.add(nodeInfo);
-    }
-  }
-
-  private static boolean isTweetSocialProofOnly(
-    SmallArrayBasedLongToDoubleMap[] socialProofs,
-    int tweetSocialProofType
-  ) {
-    boolean keep = false;
-    for (int i = 0; i < socialProofs.length; i++) {
-      if (i != tweetSocialProofType && socialProofs[i] != null) {
-        keep = true;
-        break;
-      }
-    }
-
-    return !keep;
-  }
-
-  private static boolean isLessThantMinUserSocialProofSize(
-    SmallArrayBasedLongToDoubleMap[] socialProofs,
-    int minUserSocialProofSize
-  ) {
-    boolean keep = false;
-    for (int i = 0; i < socialProofs.length; i++) {
-      if (socialProofs[i] != null && socialProofs[i].size() >= minUserSocialProofSize) {
-        keep = true;
-        break;
-      }
-    }
-
-    return !keep;
-  }
-
   /**
    * Return tweet recommendations
    *
@@ -130,22 +52,22 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
     int minUserSocialProofSize =
       request.getMinUserSocialProofSizes().containsKey(RecommendationType.TWEET)
         ? request.getMinUserSocialProofSizes().get(RecommendationType.TWEET)
-        : MIN_USER_SOCIAL_PROOF_SIZE;
+        : RecommendationRequest.DEFAULT_MIN_USER_SOCIAL_PROOF_SIZE;
 
     // handling two specific rules of tweet recommendations
     // 1. do not return tweet recommendations with only Tweet social proofs.
     // 2. do not return social proofs less than minUserSocialProofSizeForTweetRecs.
     for (NodeInfo nodeInfo : nodeInfoList) {
-      if (isTweetSocialProofOnly(nodeInfo.getSocialProofs(), 4 /* tweet social proof type */)) {
+      if (GeneratorUtils.isTweetSocialProofOnly(nodeInfo.getSocialProofs(), 4 /* tweet social proof type */)) {
         continue;
       }
-      if (isLessThantMinUserSocialProofSize(
+      if (GeneratorUtils.isLessThantMinUserSocialProofSize(
         nodeInfo.getSocialProofs(),
         minUserSocialProofSize)
       ) {
         continue;
       }
-      addResultToPriorityQueue(topResults, nodeInfo, maxNumResults);
+      GeneratorUtils.addResultToPriorityQueue(topResults, nodeInfo, maxNumResults);
     }
 
     byte[] validSocialProofs = request.getSocialProofTypes();
@@ -159,7 +81,7 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
         new TweetRecommendationInfo(
           TweetIDMask.restore(nodeInfo.getValue()),
           nodeInfo.getWeight(),
-          pickTopSocialProofs(nodeInfo.getSocialProofs(), validSocialProofs, maxSocialProofSize)));
+                GeneratorUtils.pickTopSocialProofs(nodeInfo.getSocialProofs(), validSocialProofs, maxSocialProofSize)));
     }
     Collections.reverse(outputResults);
 

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountUserRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountUserRecsGenerator.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2016 Twitter. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.graphjet.algorithms.counting;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.PriorityQueue;
+
+import com.google.common.collect.Lists;
+import com.twitter.graphjet.algorithms.*;
+
+public class TopSecondDegreeByCountUserRecsGenerator {
+
+    /**
+     * Generate a list of recommendations based on given list of candidate nodes and the original request
+     * @param request       original request message, contains filtering criteria
+     * @param nodeInfoList  list of candidate nodes
+     * @return              list of {@link UserRecommendationInfo}
+     */
+    public static List<RecommendationInfo> generateUserRecs(
+            TopSecondDegreeByCountRequest request,
+            List<NodeInfo> nodeInfoList) {
+
+        int maxNumResults = RecommendationRequest.DEFAULT_RECOMMENDATION_RESULTS;
+        if (request.getMaxNumResultsByType().containsKey(RecommendationType.USER)) {
+            maxNumResults = request.getMaxNumResultsByType().get(RecommendationType.USER);
+        }
+        PriorityQueue<NodeInfo> topResults = new PriorityQueue<>(maxNumResults);
+
+        int minUserSocialProofSize = request.getMinUserSocialProofSizes().containsKey(RecommendationType.USER) ?
+                request.getMinUserSocialProofSizes().get(RecommendationType.USER) :
+                RecommendationRequest.DEFAULT_MIN_USER_SOCIAL_PROOF_SIZE;
+
+        for (NodeInfo nodeInfo : nodeInfoList) {
+            if (GeneratorUtils.isLessThantMinUserSocialProofSize(nodeInfo.getSocialProofs(), minUserSocialProofSize)) {
+                continue;
+            }
+            GeneratorUtils.addResultToPriorityQueue(topResults, nodeInfo, maxNumResults);
+        }
+
+        byte[] validSocialProofs = request.getSocialProofTypes();
+        int maxSocialProofSize = request.getMaxUserSocialProofSize();
+
+        List<RecommendationInfo> outputResults = Lists.newArrayListWithCapacity(topResults.size());
+        while (!topResults.isEmpty()) {
+            NodeInfo nodeInfo = topResults.poll();
+            UserRecommendationInfo userRecs = new UserRecommendationInfo(
+                    TweetIDMask.restore(nodeInfo.getValue()),
+                    nodeInfo.getWeight(),
+                    GeneratorUtils.pickTopSocialProofs(nodeInfo.getSocialProofs(), validSocialProofs, maxSocialProofSize));
+            outputResults.add(userRecs);
+        }
+        Collections.reverse(outputResults);
+
+        return outputResults;
+    }
+}


### PR DESCRIPTION
This request allows GraphJet to recommend users based on user engagements, including Follow, Mention, and Mediatag. 
- new TopSecondDegreeByCount request constructor is created specifically for user recommendations
- Re-factored TopSecondDegreeByCount generators' common functions
- Added logic for user recommendation based on TopSecondDegreeByCount