### PR TITLE
GraphJet adapters for Cassovary graphs

### DIFF
--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>

--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -32,12 +32,14 @@
       <groupId>com.twitter</groupId>
       <artifactId>cassovary-core_2.10</artifactId>
       <version>6.4.0</version>
-    </dependency>
-    <dependency>
-      <!-- Cassovary depends on v0.0.37, which isn't found on Maven central. Forcing newer version -->
-      <groupId>com.twitter.common</groupId>
-      <artifactId>metrics</artifactId>
-      <version>0.0.38</version>
+      <exclusions>
+        <!-- Cassovary depends on metrics 0.0.37, which for some reason is not 
+             published in Maven central, so exclude. -->
+        <exclusion>
+          <groupId>com.twitter.common</groupId>
+          <artifactId>metrics</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.twitter</groupId>
+    <artifactId>graphjet</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <groupId>com.twitter</groupId>
+  <artifactId>graphjet-adapters</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+  <name>GraphJet Adapters</name>
+  <description>GraphJet is a real-time graph processing library: adapters for other graph systems</description>
+  <url>http://graphjet.io</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>graphjet-core</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>cassovary-core_2.10</artifactId>
+      <version>6.4.0</version>
+    </dependency>
+    <dependency>
+      <!-- Cassovary depends on v0.0.37, which isn't found on Maven central. Forcing newer version -->
+      <groupId>com.twitter.common</groupId>
+      <artifactId>metrics</artifactId>
+      <version>0.0.38</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>

--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -32,14 +32,14 @@
       <groupId>com.twitter</groupId>
       <artifactId>cassovary-core_2.10</artifactId>
       <version>6.4.0</version>
-      <exclusions>
-        <!-- Cassovary depends on metrics 0.0.37, which for some reason is not 
-             published in Maven central, so exclude. -->
-        <exclusion>
-          <groupId>com.twitter.common</groupId>
-          <artifactId>metrics</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <!-- Cassovary depends on v0.0.37, which isn't found on Maven central. Forcing newer version.
+           Note that metrics is deeply embedded into Cassovary that it won't run without it, so we
+           can't just exclude.  -->
+      <groupId>com.twitter.common</groupId>
+      <artifactId>metrics</artifactId>
+      <version>0.0.38</version>
     </dependency>
   </dependencies>
 </project>

--- a/graphjet-adapters/src/main/java/com/twitter/graphjet/adapter/cassovary/CassovaryOutIndexedDirectedGraph.java
+++ b/graphjet-adapters/src/main/java/com/twitter/graphjet/adapter/cassovary/CassovaryOutIndexedDirectedGraph.java
@@ -28,8 +28,8 @@ import scala.collection.Seq;
 import scala.Option;
 
 /**
- * A GraphJet wrapper for an out-indexed Cassovary graph. Implements the GraphJet API by delegating to the underlying
- * Cassovary API.
+ * A GraphJet wrapper for an out-indexed Cassovary graph. Implements the GraphJet API by delegating methods to the 
+ * underlying Cassovary API.
  */
 public class CassovaryOutIndexedDirectedGraph implements OutIndexedDirectedGraph {
   // This is the Cassovary graph that's being wrapped.

--- a/graphjet-adapters/src/main/java/com/twitter/graphjet/adapter/cassovary/CassovaryOutIndexedDirectedGraph.java
+++ b/graphjet-adapters/src/main/java/com/twitter/graphjet/adapter/cassovary/CassovaryOutIndexedDirectedGraph.java
@@ -1,0 +1,103 @@
+package com.twitter.graphjet.adapter.cassovary;
+
+import java.util.Random;
+
+import com.twitter.cassovary.graph.DirectedGraph;
+import com.twitter.cassovary.graph.Node;
+import com.twitter.cassovary.graph.GraphDir;
+import com.twitter.graphjet.directed.api.OutIndexedDirectedGraph;
+import com.twitter.graphjet.bipartite.api.EdgeIterator;
+
+import scala.collection.Seq;
+import scala.Option;
+
+
+public class CassovaryOutIndexedDirectedGraph implements OutIndexedDirectedGraph {
+  // This is the Cassovary graph that's being wrapped.
+  final private DirectedGraph<Node> graph;
+
+  public CassovaryOutIndexedDirectedGraph(DirectedGraph<Node> graph) {
+    if (!graph.isDirStored(GraphDir.OutDir()) || graph.isBiDirectional()) {
+      // If the graph isn't out-indexed or if the graph is bidirectional, we should be using a different wrapper class.
+      throw new IncompatibleCassovaryGraphException();
+    }
+    this.graph = graph;
+  }
+
+  public int getOutDegree(long node) {
+    return graph.getNodeById((int) node).get().outboundCount();
+  }
+
+  public EdgeIterator getOutEdges(long node) {
+    Option<Node> opt = graph.getNodeById((int) node);
+    if (opt.isEmpty()) {
+      return new EmptyEdgeIterator();
+    }
+
+    return new SeqEdgeIteratorWrapper(opt.get().outboundNodes());
+  }
+
+  public EdgeIterator getRandomOutEdges(long node, int numSamples, Random random) {
+    Option<Node> opt = graph.getNodeById((int) node);
+    if (opt.isEmpty()) {
+      return new EmptyEdgeIterator();
+    }
+
+    return new SeqEdgeIteratorWrapper(opt.get().randomOutboundNodeSet(
+        numSamples, scala.util.Random.javaRandomToRandom(random)));
+  }
+
+  private class SeqEdgeIteratorWrapper implements EdgeIterator {
+    final private Seq seq;
+    private int index = 0;
+
+    public SeqEdgeIteratorWrapper(Seq seq) {
+      this.seq = seq;
+      index = 0;
+    }
+
+    public byte currentEdgeType() {
+      // Always return 0 since Cassovary edges aren't typed.
+      return 0;
+    }
+
+    public boolean hasNext() {
+      return index < seq.length();
+    }
+
+    public long nextLong() {
+      return (long) (int) seq.apply(index++);
+    }
+
+    public Long next() {
+      return (Long) seq.apply(index++);
+    }
+
+    public int skip(int n) {
+      // TODO: This doesn't work yet.
+      return 0;
+    }
+  }
+
+  private class EmptyEdgeIterator implements EdgeIterator {
+    public byte currentEdgeType() {
+      return 0;
+    }
+
+    public boolean hasNext() {
+      return false;
+    }
+
+    public long nextLong() {
+      return 0;
+    }
+
+    public Long next() {
+      return 0L;
+    }
+
+    public int skip(int n) {
+      return 0;
+    }
+  }
+}

--- a/graphjet-adapters/src/main/java/com/twitter/graphjet/adapter/cassovary/CassovaryOutIndexedDirectedGraph.java
+++ b/graphjet-adapters/src/main/java/com/twitter/graphjet/adapter/cassovary/CassovaryOutIndexedDirectedGraph.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2016 Twitter. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.twitter.graphjet.adapter.cassovary;
 
 import java.util.Random;
@@ -11,11 +27,19 @@ import com.twitter.graphjet.bipartite.api.EdgeIterator;
 import scala.collection.Seq;
 import scala.Option;
 
-
+/**
+ * A GraphJet wrapper for an out-indexed Cassovary graph. Implements the GraphJet API by delegating to the underlying
+ * Cassovary API.
+ */
 public class CassovaryOutIndexedDirectedGraph implements OutIndexedDirectedGraph {
   // This is the Cassovary graph that's being wrapped.
   final private DirectedGraph<Node> graph;
 
+  /**
+   * Constructs a GraphJet wrapper for an out-indexed Cassovart graph.
+   *
+   * @param graph the Cassovary graph
+   */
   public CassovaryOutIndexedDirectedGraph(DirectedGraph<Node> graph) {
     if (!graph.isDirStored(GraphDir.OutDir()) || graph.isBiDirectional()) {
       // If the graph isn't out-indexed or if the graph is bidirectional, we should be using a different wrapper class.
@@ -24,10 +48,12 @@ public class CassovaryOutIndexedDirectedGraph implements OutIndexedDirectedGraph
     this.graph = graph;
   }
 
+  @Override
   public int getOutDegree(long node) {
     return graph.getNodeById((int) node).get().outboundCount();
   }
 
+  @Override
   public EdgeIterator getOutEdges(long node) {
     Option<Node> opt = graph.getNodeById((int) node);
     if (opt.isEmpty()) {
@@ -37,6 +63,7 @@ public class CassovaryOutIndexedDirectedGraph implements OutIndexedDirectedGraph
     return new SeqEdgeIteratorWrapper(opt.get().outboundNodes());
   }
 
+  @Override
   public EdgeIterator getRandomOutEdges(long node, int numSamples, Random random) {
     Option<Node> opt = graph.getNodeById((int) node);
     if (opt.isEmpty()) {
@@ -47,6 +74,9 @@ public class CassovaryOutIndexedDirectedGraph implements OutIndexedDirectedGraph
         numSamples, scala.util.Random.javaRandomToRandom(random)));
   }
 
+  /**
+   * Wrapper for a Scala Seq as an EdgeIterator.
+   */
   private class SeqEdgeIteratorWrapper implements EdgeIterator {
     final private Seq seq;
     private int index = 0;
@@ -56,46 +86,65 @@ public class CassovaryOutIndexedDirectedGraph implements OutIndexedDirectedGraph
       index = 0;
     }
 
+    @Override
     public byte currentEdgeType() {
       // Always return 0 since Cassovary edges aren't typed.
       return 0;
     }
 
+    @Override
     public boolean hasNext() {
       return index < seq.length();
     }
 
+    @Override
     public long nextLong() {
       return (long) (int) seq.apply(index++);
     }
 
+    @Override
     public Long next() {
       return (Long) seq.apply(index++);
     }
 
+    @Override
     public int skip(int n) {
-      // TODO: This doesn't work yet.
-      return 0;
+      if ( index+n < seq.length()) {
+        index+=n;
+        return n;
+      }
+
+      int skipped = seq.length()-index;
+      index = seq.length();
+      return skipped;
     }
   }
 
+  /**
+   * An empty EdgeIterator.
+   */
   private class EmptyEdgeIterator implements EdgeIterator {
+    @Override
     public byte currentEdgeType() {
       return 0;
     }
 
+    @Override
     public boolean hasNext() {
       return false;
     }
 
+    @Override
     public long nextLong() {
       return 0;
     }
 
+    @Override
     public Long next() {
       return 0L;
     }
 
+    @Override
     public int skip(int n) {
       return 0;
     }

--- a/graphjet-adapters/src/main/java/com/twitter/graphjet/adapter/cassovary/IncompatibleCassovaryGraphException.java
+++ b/graphjet-adapters/src/main/java/com/twitter/graphjet/adapter/cassovary/IncompatibleCassovaryGraphException.java
@@ -1,0 +1,3 @@
+package com.twitter.graphjet.adapter.cassovary;
+
+public class IncompatibleCassovaryGraphException extends RuntimeException {}

--- a/graphjet-adapters/src/main/java/com/twitter/graphjet/adapter/cassovary/IncompatibleCassovaryGraphException.java
+++ b/graphjet-adapters/src/main/java/com/twitter/graphjet/adapter/cassovary/IncompatibleCassovaryGraphException.java
@@ -1,3 +1,23 @@
+/**
+ * Copyright 2016 Twitter. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.twitter.graphjet.adapter.cassovary;
 
+/**
+ * Exception denoting a mismatch between the Cassovary graph being wrapped and the GraphJet wrapper. Thrown, for
+ * example, if the out-indexed GraphJet wrapper class is called on the in-indexed Cassovary graph.
+ */
 public class IncompatibleCassovaryGraphException extends RuntimeException {}

--- a/graphjet-adapters/src/test/java/com/twitter/graphjet/adapter/cassovary/CassovaryOutIndexedDirectedGraphTest.java
+++ b/graphjet-adapters/src/test/java/com/twitter/graphjet/adapter/cassovary/CassovaryOutIndexedDirectedGraphTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2016 Twitter. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.twitter.graphjet.adapter.cassovary;
 
 import org.junit.Test;
@@ -14,9 +30,6 @@ import com.twitter.graphjet.bipartite.api.EdgeIterator;
 public class CassovaryOutIndexedDirectedGraphTest {
   @Test
   public void testG6() throws Exception {
-    DirectedGraph<Node> graph = com.twitter.cassovary.graph.TestGraphs.g6_onlyout();
-    System.out.println(graph.toString());
-
     CassovaryOutIndexedDirectedGraph g = new CassovaryOutIndexedDirectedGraph(TestGraphs.g6_onlyout());
     assertEquals(3, g.getOutDegree(10));
     assertEquals(2, g.getOutDegree(11));
@@ -63,5 +76,47 @@ public class CassovaryOutIndexedDirectedGraphTest {
   @Test(expected=IncompatibleCassovaryGraphException.class)
   public void testIncompatibleGraph2() throws Exception {
     CassovaryOutIndexedDirectedGraph g = new CassovaryOutIndexedDirectedGraph(TestGraphs.g6());
+  }
+
+  @Test
+  public void testSkipping() throws Exception {
+    CassovaryOutIndexedDirectedGraph g = new CassovaryOutIndexedDirectedGraph(TestGraphs.g6_onlyout());
+    // node 10 -> 11, 12, 13
+
+    EdgeIterator iter = g.getOutEdges(10);
+    assertEquals(true, iter.hasNext());
+    assertEquals(11, iter.nextLong());
+    assertEquals(true, iter.hasNext());
+    assertEquals(1, iter.skip(1));
+    assertEquals(true, iter.hasNext());
+    assertEquals(13, iter.nextLong());
+    assertEquals(false, iter.hasNext());
+
+    iter = g.getOutEdges(10);
+    assertEquals(true, iter.hasNext());
+    assertEquals(1, iter.skip(1));
+    assertEquals(true, iter.hasNext());
+    assertEquals(12, iter.nextLong());
+    assertEquals(1, iter.skip(1));
+    assertEquals(false, iter.hasNext());
+
+    iter = g.getOutEdges(10);
+    assertEquals(true, iter.hasNext());
+    assertEquals(3, iter.skip(10));
+    assertEquals(false, iter.hasNext());
+
+    iter = g.getOutEdges(10);
+    assertEquals(true, iter.hasNext());
+    assertEquals(11, iter.nextLong());
+    assertEquals(true, iter.hasNext());
+    assertEquals(2, iter.skip(10));
+    assertEquals(false, iter.hasNext());
+
+    iter = g.getOutEdges(10);
+    assertEquals(true, iter.hasNext());
+    assertEquals(2, iter.skip(2));
+    assertEquals(true, iter.hasNext());
+    assertEquals(13, iter.nextLong());
+    assertEquals(false, iter.hasNext());
   }
 }

--- a/graphjet-adapters/src/test/java/com/twitter/graphjet/adapter/cassovary/CassovaryOutIndexedDirectedGraphTest.java
+++ b/graphjet-adapters/src/test/java/com/twitter/graphjet/adapter/cassovary/CassovaryOutIndexedDirectedGraphTest.java
@@ -1,0 +1,67 @@
+package com.twitter.graphjet.adapter.cassovary;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.twitter.cassovary.graph.DirectedGraph;
+import com.twitter.cassovary.graph.Node;
+import com.twitter.cassovary.graph.TestGraphs;
+
+import com.twitter.graphjet.bipartite.api.EdgeIterator;
+
+public class CassovaryOutIndexedDirectedGraphTest {
+  @Test
+  public void testG6() throws Exception {
+    DirectedGraph<Node> graph = com.twitter.cassovary.graph.TestGraphs.g6_onlyout();
+    System.out.println(graph.toString());
+
+    CassovaryOutIndexedDirectedGraph g = new CassovaryOutIndexedDirectedGraph(TestGraphs.g6_onlyout());
+    assertEquals(3, g.getOutDegree(10));
+    assertEquals(2, g.getOutDegree(11));
+    assertEquals(1, g.getOutDegree(12));
+    assertEquals(2, g.getOutDegree(13));
+    assertEquals(1, g.getOutDegree(14));
+    assertEquals(2, g.getOutDegree(15));
+
+    EdgeIterator iter = g.getOutEdges(10);
+    assertEquals(true, iter.hasNext());
+    assertEquals(true, iter.hasNext());
+    assertEquals(true, iter.hasNext());
+    // Note, calling hasNext() multiple times shouldn't make a difference.
+    assertEquals(11, iter.nextLong());
+    assertEquals(true, iter.hasNext());
+    assertEquals(12, iter.nextLong());
+    assertEquals(true, iter.hasNext());
+    assertEquals(13, iter.nextLong());
+    assertEquals(false, iter.hasNext());
+
+    iter = g.getOutEdges(11);
+    assertEquals(12, iter.nextLong());
+    assertEquals(14, iter.nextLong());
+    assertEquals(false, iter.hasNext());
+
+    iter = g.getOutEdges(15);
+    assertEquals(true, iter.hasNext());
+    assertEquals(10, iter.nextLong());
+    assertEquals(11, iter.nextLong());
+    assertEquals(false, iter.hasNext());
+
+    // Try fetching edges from a node that doesn't exist.
+    iter = g.getOutEdges(0);
+    assertEquals(false, iter.hasNext());
+  }
+
+  @SuppressWarnings("unused")
+  @Test(expected=IncompatibleCassovaryGraphException.class)
+  public void testIncompatibleGraph1() throws Exception {
+    CassovaryOutIndexedDirectedGraph g = new CassovaryOutIndexedDirectedGraph(TestGraphs.g6_onlyin());
+  }
+
+  @SuppressWarnings("unused")
+  @Test(expected=IncompatibleCassovaryGraphException.class)
+  public void testIncompatibleGraph2() throws Exception {
+    CassovaryOutIndexedDirectedGraph g = new CassovaryOutIndexedDirectedGraph(TestGraphs.g6());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
   <modules>
     <module>graphjet-core</module>
     <module>graphjet-demo</module>
+    <module>graphjet-adapters</module>
   </modules>
 
 </project>


### PR DESCRIPTION
Initial implementation of GraphJet adapters for Cassovary graphs. This is so we can benchmark GraphJet vs. Cassovary in a common framework.