### PR TITLE
Deduplicating social proofs in TopSecondDegreeByCount

### DIFF
--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/NodeInfo.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/NodeInfo.java
@@ -108,8 +108,7 @@ public class NodeInfo implements Comparable<NodeInfo> {
       socialProofs[edgeType] = new SmallArrayBasedLongToDoubleMap();
     }
 
-    socialProofs[edgeType].put(node, nodeWeight);
-    return true;
+    return socialProofs[edgeType].put(node, nodeWeight);
   }
 
   public int[] getNodeMetadata(int nodeMetadataType) {

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCount.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCount.java
@@ -146,7 +146,7 @@ public abstract class TopSecondDegreeByCount<Request extends TopSecondDegreeByCo
           seenEdgesPerNode.containsKey(rightNode) && seenEdgesPerNode.get(rightNode) == edgeType;
 
         if (!hasSeenRightNodeFromEdge) {
-          seenEdgesPerNode.put(rightNode, edgeType);
+          seenEdgesPerNode.put(rightNode, edgeType); // This only checks the most recently engaged edge type
           int maxSocialProofTypeSize = request.getMaxSocialProofTypeSize();
           updateNodeInfo(
             leftNode,

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountForTweet.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountForTweet.java
@@ -89,8 +89,9 @@ public class TopSecondDegreeByCountForTweet extends
       nodeInfo = super.visitedRightNodes.get(rightNode);
     }
 
-    nodeInfo.addToWeight(weight);
-    nodeInfo.addToSocialProof(leftNode, edgeType, weight);
+    if (nodeInfo.addToSocialProof(leftNode, edgeType, weight)) {
+      nodeInfo.addToWeight(weight);
+    }
   }
 
   @Override

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountForUser.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountForUser.java
@@ -63,8 +63,9 @@ public class TopSecondDegreeByCountForUser extends
       nodeInfo = super.visitedRightNodes.get(rightNode);
     }
 
-    nodeInfo.addToWeight(weight);
-    nodeInfo.addToSocialProof(leftNode, edgeType, weight);
+    if (nodeInfo.addToSocialProof(leftNode, edgeType, weight)) {
+      nodeInfo.addToWeight(weight);
+    }
   }
 
   @Override


### PR DESCRIPTION
Currently in TopSecondDegreeByCount algorithm, for each right node engaged with, it only checks the most recently engaged edge type from a given left node. Therefore, in a situation where a left node engages with a right node through edge types like "favorite, reply, favorite", favorite will be counted twice. This causes one engagement type to be counted more than once.
This commit makes sure this does not happen.