### PR TITLE
Change graph type for user recommendations. Also bug fix in user rec

### DIFF
--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCount.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCount.java
@@ -19,8 +19,8 @@ package com.twitter.graphjet.algorithms.counting;
 import com.twitter.graphjet.algorithms.NodeInfo;
 import com.twitter.graphjet.algorithms.RecommendationAlgorithm;
 import com.twitter.graphjet.algorithms.RecommendationStats;
-import com.twitter.graphjet.bipartite.NodeMetadataLeftIndexedMultiSegmentBipartiteGraph;
-import com.twitter.graphjet.bipartite.NodeMetadataMultiSegmentIterator;
+import com.twitter.graphjet.bipartite.LeftIndexedMultiSegmentBipartiteGraph;
+import com.twitter.graphjet.bipartite.api.EdgeIterator;
 import com.twitter.graphjet.stats.Counter;
 import com.twitter.graphjet.stats.StatsReceiver;
 import it.unimi.dsi.fastutil.longs.*;
@@ -43,7 +43,7 @@ public abstract class TopSecondDegreeByCount<Request extends TopSecondDegreeByCo
   protected static final int MAX_EDGES_PER_NODE = 500;
 
   // Static variables for better memory reuse. Avoids re-allocation on every request
-  private final NodeMetadataLeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph;
+  private final LeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph;
   private final Long2ByteMap seenEdgesPerNode;
   protected final Long2ObjectMap<NodeInfo> visitedRightNodes;
   protected final List<NodeInfo> nodeInfosAfterFiltering;
@@ -53,7 +53,7 @@ public abstract class TopSecondDegreeByCount<Request extends TopSecondDegreeByCo
 
   /**
    * @param leftIndexedBipartiteGraph is the
-   *                                  {@link NodeMetadataLeftIndexedMultiSegmentBipartiteGraph}
+   *                                  {@link LeftIndexedMultiSegmentBipartiteGraph
    *                                  to run TopSecondDegreeByCountForTweet on
    * @param expectedNodesToHit        is an estimate of how many nodes can be hit in
    *                                  TopSecondDegreeByCountForTweet. This is purely for allocating needed
@@ -61,7 +61,7 @@ public abstract class TopSecondDegreeByCount<Request extends TopSecondDegreeByCo
    * @param statsReceiver             tracks the internal stats
    */
   public TopSecondDegreeByCount(
-    NodeMetadataLeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph,
+    LeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph,
     int expectedNodesToHit,
     StatsReceiver statsReceiver) {
     this.leftIndexedBipartiteGraph = leftIndexedBipartiteGraph;
@@ -88,7 +88,7 @@ public abstract class TopSecondDegreeByCount<Request extends TopSecondDegreeByCo
     long rightNode,
     byte edgeType,
     double weight,
-    NodeMetadataMultiSegmentIterator edgeIterator,
+    EdgeIterator edgeIterator,
     int maxSocialProofTypeSize);
 
   /**
@@ -130,8 +130,7 @@ public abstract class TopSecondDegreeByCount<Request extends TopSecondDegreeByCo
       long leftNode = entry.getLongKey();
       double weight = entry.getDoubleValue();
       int numEdgesPerNode = 0;
-      NodeMetadataMultiSegmentIterator edgeIterator =
-        (NodeMetadataMultiSegmentIterator) leftIndexedBipartiteGraph.getLeftNodeEdges(leftNode);
+      EdgeIterator edgeIterator = leftIndexedBipartiteGraph.getLeftNodeEdges(leftNode);
       seenEdgesPerNode.clear();
 
       if (edgeIterator == null) {

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountForTweet.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountForTweet.java
@@ -27,6 +27,7 @@ import com.twitter.graphjet.algorithms.counting.TopSecondDegreeByCount;
 import com.twitter.graphjet.algorithms.counting.TopSecondDegreeByCountResponse;
 import com.twitter.graphjet.bipartite.NodeMetadataLeftIndexedMultiSegmentBipartiteGraph;
 import com.twitter.graphjet.bipartite.NodeMetadataMultiSegmentIterator;
+import com.twitter.graphjet.bipartite.api.EdgeIterator;
 import com.twitter.graphjet.hashing.IntArrayIterator;
 import com.twitter.graphjet.stats.StatsReceiver;
 
@@ -60,7 +61,7 @@ public class TopSecondDegreeByCountForTweet extends
     long rightNode,
     byte edgeType,
     double weight,
-    NodeMetadataMultiSegmentIterator edgeIterator,
+    EdgeIterator edgeIterator,
     int maxSocialProofTypeSize) {
     NodeInfo nodeInfo;
 
@@ -71,7 +72,7 @@ public class TopSecondDegreeByCountForTweet extends
 
       for (int i = 0; i < metadataSize; i++) {
         IntArrayIterator metadataIterator =
-          (IntArrayIterator) edgeIterator.getRightNodeMetadata((byte) i);
+          (IntArrayIterator) ((NodeMetadataMultiSegmentIterator)edgeIterator).getRightNodeMetadata((byte) i);
 
         if (metadataIterator.size() > 0) {
           int[] metadata = new int[metadataIterator.size()];

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountForUser.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountForUser.java
@@ -20,8 +20,8 @@ import com.twitter.graphjet.algorithms.NodeInfo;
 import com.twitter.graphjet.algorithms.RecommendationInfo;
 import com.twitter.graphjet.algorithms.counting.TopSecondDegreeByCount;
 import com.twitter.graphjet.algorithms.counting.TopSecondDegreeByCountResponse;
-import com.twitter.graphjet.bipartite.NodeMetadataLeftIndexedMultiSegmentBipartiteGraph;
-import com.twitter.graphjet.bipartite.NodeMetadataMultiSegmentIterator;
+import com.twitter.graphjet.bipartite.LeftIndexedPowerLawMultiSegmentBipartiteGraph;
+import com.twitter.graphjet.bipartite.api.EdgeIterator;
 import com.twitter.graphjet.stats.StatsReceiver;
 
 import java.util.List;
@@ -32,15 +32,15 @@ public class TopSecondDegreeByCountForUser extends
   /**
    * Construct a TopSecondDegreeByCount algorithm runner for user related recommendations.
    * @param leftIndexedBipartiteGraph is the
-   *                                  {@link NodeMetadataLeftIndexedMultiSegmentBipartiteGraph}
-   *                                  to run TopSecondDegreeByCountForTweet on
+   *                                  {@link LeftIndexedPowerLawMultiSegmentBipartiteGraph}
+   *                                  to run TopSecondDegreeByCountForUser on
    * @param expectedNodesToHit        is an estimate of how many nodes can be hit in
    *                                  TopSecondDegreeByCountForUser. This is purely for allocating needed
    *                                  memory right up front to make requests fast.
    * @param statsReceiver             tracks the internal stats
    */
   public TopSecondDegreeByCountForUser(
-    NodeMetadataLeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph,
+    LeftIndexedPowerLawMultiSegmentBipartiteGraph leftIndexedBipartiteGraph,
     int expectedNodesToHit,
     StatsReceiver statsReceiver) {
     super(leftIndexedBipartiteGraph, expectedNodesToHit, statsReceiver);
@@ -52,7 +52,7 @@ public class TopSecondDegreeByCountForUser extends
     long rightNode,
     byte edgeType,
     double weight,
-    NodeMetadataMultiSegmentIterator edgeIterator,
+    EdgeIterator edgeIterator,
     int maxSocialProofTypeSize) {
     NodeInfo nodeInfo;
 

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountRequestForUser.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountRequestForUser.java
@@ -30,13 +30,14 @@ import java.util.Map;
 public class TopSecondDegreeByCountRequestForUser extends TopSecondDegreeByCountRequest {
   private final Map<Byte, Integer> minUserPerSocialProof;
   private final int maxNumResults;
+  private final int maxNumSocialProofs;
   private final RecommendationType recommendationType = RecommendationType.USER;
-
   /**
    * @param queryNode                 is the query node for running TopSecondDegreeByCountForUser
    * @param leftSeedNodesWithWeight   is the set of seed nodes and their weights to use for calculation
    * @param toBeFiltered              is the list of users to be excluded from recommendations
    * @param maxNumResults             is the maximum number of recommendations returned in the response
+   * @param maxNumSocialProofs        is the maximum number of social proofs per recommendation
    * @param maxSocialProofTypeSize    is the number of social proof types in the graph
    * @param minUserPerSocialProof     for each social proof, require a minimum number of users to be valid
    * @param socialProofTypes          is the list of valid social proofs, (i.e, Follow, Mention, Mediatag)
@@ -47,12 +48,14 @@ public class TopSecondDegreeByCountRequestForUser extends TopSecondDegreeByCount
     Long2DoubleMap leftSeedNodesWithWeight,
     LongSet toBeFiltered,
     int maxNumResults,
+    int maxNumSocialProofs,
     int maxSocialProofTypeSize,
     Map<Byte, Integer> minUserPerSocialProof,
     byte[] socialProofTypes,
     ResultFilterChain resultFilterChain) {
     super(queryNode, leftSeedNodesWithWeight, toBeFiltered, maxSocialProofTypeSize, socialProofTypes, resultFilterChain);
     this.maxNumResults = maxNumResults;
+    this.maxNumSocialProofs = maxNumSocialProofs;
     this.minUserPerSocialProof = minUserPerSocialProof;
   }
 
@@ -60,5 +63,7 @@ public class TopSecondDegreeByCountRequestForUser extends TopSecondDegreeByCount
 
   public int getMaxNumResults() { return maxNumResults; }
 
-  public RecommendationType getRecommendationType() { return recommendationType;}
+  public int getMaxNumSocialProofs() {return maxNumSocialProofs; }
+
+  public RecommendationType getRecommendationType() { return recommendationType; }
 }

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountRequestForUser.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountRequestForUser.java
@@ -63,7 +63,7 @@ public class TopSecondDegreeByCountRequestForUser extends TopSecondDegreeByCount
 
   public int getMaxNumResults() { return maxNumResults; }
 
-  public int getMaxNumSocialProofs() {return maxNumSocialProofs; }
+  public int getMaxNumSocialProofs() { return maxNumSocialProofs; }
 
   public RecommendationType getRecommendationType() { return recommendationType; }
 }

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountUserRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountUserRecsGenerator.java
@@ -91,7 +91,7 @@ public final class TopSecondDegreeByCountUserRecsGenerator {
     PriorityQueue<NodeInfo> topNodes) {
     List<RecommendationInfo> outputResults = Lists.newArrayListWithCapacity(topNodes.size());
     byte[] validSocialProofs = request.getSocialProofTypes();
-    int maxSocialProofSize = request.getMaxSocialProofTypeSize();
+    int maxNumSocialProofs = request.getMaxNumSocialProofs();
 
     while (!topNodes.isEmpty()) {
       NodeInfo nodeInfo = topNodes.poll();
@@ -99,7 +99,7 @@ public final class TopSecondDegreeByCountUserRecsGenerator {
       Map<Byte, LongList> topSocialProofs = GeneratorHelper.pickTopSocialProofs(
         nodeInfo.getSocialProofs(),
         validSocialProofs,
-        maxSocialProofSize);
+        maxNumSocialProofs);
 
       UserRecommendationInfo userRecs = new UserRecommendationInfo(
         nodeInfo.getValue(),

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/BipartiteGraphTestHelper.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/BipartiteGraphTestHelper.java
@@ -19,6 +19,7 @@ package com.twitter.graphjet.algorithms;
 
 import java.util.Random;
 
+import com.twitter.graphjet.bipartite.LeftIndexedPowerLawMultiSegmentBipartiteGraph;
 import com.twitter.graphjet.bipartite.NodeMetadataLeftIndexedMultiSegmentBipartiteGraph;
 import com.twitter.graphjet.bipartite.NodeMetadataLeftIndexedPowerLawMultiSegmentBipartiteGraph;
 import com.twitter.graphjet.bipartite.segment.HigherBitsEdgeTypeMask;
@@ -244,6 +245,43 @@ public final class BipartiteGraphTestHelper {
     return nodeMetadataGraph;
   }
 
+  /**
+   * Build a small test LeftIndexedPowerLawMultiSegmentBipartiteGraph.
+   *
+   * @return a small test {@link LeftIndexedPowerLawMultiSegmentBipartiteGraph}
+   */
+  public static LeftIndexedPowerLawMultiSegmentBipartiteGraph
+  buildSmallTestLeftIndexedPowerLawMultiSegmentBipartiteGraphWithEdgeTypes() {
+    LeftIndexedPowerLawMultiSegmentBipartiteGraph nodeMetadataGraph =
+      new LeftIndexedPowerLawMultiSegmentBipartiteGraph(
+        2,
+        10,
+        2,
+        6,
+        2.0,
+        6,
+        new HigherBitsEdgeTypeMask(),
+        new NullStatsReceiver()
+      );
+    nodeMetadataGraph.addEdge(1, 2, (byte) 0);
+
+    nodeMetadataGraph.addEdge(1, 3, (byte) 1);
+    nodeMetadataGraph.addEdge(2, 3, (byte) 1);
+    nodeMetadataGraph.addEdge(3, 3, (byte) 1);
+
+    nodeMetadataGraph.addEdge(1, 4, (byte) 2);
+
+    nodeMetadataGraph.addEdge(1, 5, (byte) 3);
+    nodeMetadataGraph.addEdge(2, 5, (byte) 0);
+
+    nodeMetadataGraph.addEdge(2, 6, (byte) 0);
+    nodeMetadataGraph.addEdge(2, 6, (byte) 1);
+
+    nodeMetadataGraph.addEdge(1, 7, (byte) 0);
+    nodeMetadataGraph.addEdge(2, 7, (byte) 1);
+
+    return nodeMetadataGraph;
+  }
 
   /**
    * Build a random NodeMetadataLeftIndexedMultiSegmentBipartiteGraph of given left size.

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTest.java
@@ -32,6 +32,8 @@ import com.twitter.graphjet.algorithms.counting.tweet.TopSecondDegreeByCountRequ
 import com.twitter.graphjet.algorithms.counting.user.TopSecondDegreeByCountRequestForUser;
 import com.twitter.graphjet.algorithms.counting.tweet.TopSecondDegreeByCountForTweet;
 import com.twitter.graphjet.algorithms.counting.user.TopSecondDegreeByCountForUser;
+import com.twitter.graphjet.bipartite.LeftIndexedMultiSegmentBipartiteGraph;
+import com.twitter.graphjet.bipartite.LeftIndexedPowerLawMultiSegmentBipartiteGraph;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -352,11 +354,12 @@ public class TopSecondDegreeByCountTest {
       int maxNumResults,
       Map<Byte, Integer> minUserPerSocialProof,
       List<UserRecommendationInfo> expectedTopResults) throws Exception {
-    NodeMetadataLeftIndexedMultiSegmentBipartiteGraph bipartiteGraph =
-        BipartiteGraphTestHelper.buildSmallTestNodeMetadataLeftIndexedMultiSegmentBipartiteGraphWithEdgeTypes();
+    LeftIndexedPowerLawMultiSegmentBipartiteGraph bipartiteGraph =
+        BipartiteGraphTestHelper.buildSmallTestLeftIndexedPowerLawMultiSegmentBipartiteGraphWithEdgeTypes();
 
     long queryNode = 1;
     int maxSocialProofSize = 4;
+    int maxNumSocialProofs = 100;
     Long2DoubleMap seedsMap = new Long2DoubleArrayMap(new long[]{1, 2, 3}, new double[]{1.5, 1.0, 0.5});
     LongSet toBeFiltered = new LongOpenHashSet(new long[]{});
     byte[] socialProofTypes = new byte[]{0, 1, 2, 3};
@@ -368,14 +371,15 @@ public class TopSecondDegreeByCountTest {
     Random random = new Random(randomSeed);
 
     TopSecondDegreeByCountRequestForUser request = new TopSecondDegreeByCountRequestForUser(
-        queryNode,
-        seedsMap,
-        toBeFiltered,
-        maxNumResults,
-        maxSocialProofSize,
-        minUserPerSocialProof,
-        socialProofTypes,
-        resultFilterChain);
+      queryNode,
+      seedsMap,
+      toBeFiltered,
+      maxNumResults,
+      maxNumSocialProofs,
+      maxSocialProofSize,
+      minUserPerSocialProof,
+      socialProofTypes,
+      resultFilterChain);
 
     try {
       TopSecondDegreeByCountResponse response = new TopSecondDegreeByCountForUser(


### PR DESCRIPTION
1. Changed the type of graph used by user recommendation to LeftLeftIndexedPowerLawMultiSegmentBipartiteGraph, whereas originally it uses NodeMetadata which serves little purpose. 
2. Added a new parameter to user recommendation function all (maxNumSocialProof) to limit the number of social proofs returned for each user recommendation.
3. Fixed a bug in user recommendation where social proofs get accidentally trimmed to a maximum of 3 per recommendation. 