### PR TITLE
Jjiang/return tweet withonesocialproof

### DIFF
--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/socialproof/TweetSocialProof.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/socialproof/TweetSocialProof.java
@@ -130,10 +130,13 @@ public class TweetSocialProof implements
 
     List<RecommendationInfo> socialProofList = new LinkedList<>();
     for (Long tweetId : request.getInputTweets()) {
-      socialProofList.add(new SocialProofResult(
-        tweetId,
-        tweetsInteractions.getOrDefault(tweetId, EMPTY_SOCIALPROOF_MAP),
-        tweetsSocialProofWeights.getOrDefault(tweetId, 0.0)));
+      // Return tweets with at least one social proof
+      if (tweetsInteractions.containsKey(tweetId)) {
+        socialProofList.add(new SocialProofResult(
+          tweetId,
+          tweetsInteractions.getOrDefault(tweetId, EMPTY_SOCIALPROOF_MAP),
+          tweetsSocialProofWeights.getOrDefault(tweetId, 0.0)));
+      }
     }
 
     return new SocialProofResponse(socialProofList);

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/socialproof/TweetSocialProof.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/socialproof/TweetSocialProof.java
@@ -130,7 +130,7 @@ public class TweetSocialProof implements
 
     List<RecommendationInfo> socialProofList = new LinkedList<>();
     for (Long tweetId : request.getInputTweets()) {
-      // Return tweets with at least one social proof
+      // Return only tweets with at least one social proof
       if (tweetsInteractions.containsKey(tweetId)) {
         socialProofList.add(new SocialProofResult(
           tweetId,

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/socialproof/TweetSocialProof.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/socialproof/TweetSocialProof.java
@@ -130,7 +130,7 @@ public class TweetSocialProof implements
 
     List<RecommendationInfo> socialProofList = new LinkedList<>();
     for (Long tweetId : request.getInputTweets()) {
-      // Return only tweets with at least one social proof
+      // Return only tweet ids with at least one social proof
       if (tweetsInteractions.containsKey(tweetId)) {
         socialProofList.add(new SocialProofResult(
           tweetId,

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/socialproof/TweetSocialProof.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/socialproof/TweetSocialProof.java
@@ -40,8 +40,8 @@ import it.unimi.dsi.fastutil.longs.LongSet;
 
 /**
  * TweetSocialProof shares similar logic with the TopSecondDegreeByCountForTweet class.
- * TweetSocialProof serves request with a seed user set and tweets set. It finds the social proof
- * for given tweets and return an empty map if there is none.
+ * TweetSocialProof serves request with a seed user set and tweets set. All tweets with at least one
+ * social proof will be returned to clients, and tweets without social proofs will not be returned.
  */
 public class TweetSocialProof implements
   RecommendationAlgorithm<SocialProofRequest, SocialProofResponse> {

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/socialproof/TweetSocialProof.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/socialproof/TweetSocialProof.java
@@ -39,9 +39,12 @@ import it.unimi.dsi.fastutil.longs.LongArraySet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 
 /**
- * TweetSocialProof shares similar logic with the TopSecondDegreeByCountForTweet class.
- * TweetSocialProof serves request with a seed user set and tweets set. All tweets with at least one
- * social proof will be returned to clients, and tweets without social proofs will not be returned.
+ * TweetSocialProof shares similar logic with
+ * {@link com.twitter.graphjet.algorithms.counting.tweet.TopSecondDegreeByCountForTweet}. In the
+ * request, clients specify a seed user set and a tweet set. TweetSocialProof finds the intersection
+ * between the seed user's tweet engagement set and the given tweet set from clients. All tweets
+ * with at least one social proof will be returned to clients, and tweets without social proofs will
+ * not appear in the list of the results.
  */
 public class TweetSocialProof implements
   RecommendationAlgorithm<SocialProofRequest, SocialProofResponse> {


### PR DESCRIPTION
FindTweetSocialProofs API has an inefficiency which adds unnecessary workload on both server and client side. Currently, the API takes a list of tweet ids, tries to find the social proofs for each of them and returns all tweet ids in thrift objects regardless whether it finds social proof or not. This rb will return only tweet ids with at least one social proof.