### PR TITLE
Update how socialProofTypes are used for filtering

### DIFF
--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-adapters</artifactId>
-  <version>1.0.6-SNAPSHOT</version>
+  <version>1.0.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Adapters</name>
   <description>GraphJet is a real-time graph processing library: adapters for other graph systems</description>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.0.6-SNAPSHOT</version>
+      <version>1.0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>

--- a/graphjet-core/pom.xml
+++ b/graphjet-core/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-core</artifactId>
-  <version>1.0.6-SNAPSHOT</version>
+  <version>1.0.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Core</name>
   <description>GraphJet is a real-time graph processing library: core graph library and recommendation algorithms</description>

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/SocialProofTypesFilter.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/SocialProofTypesFilter.java
@@ -45,14 +45,11 @@ public class SocialProofTypesFilter extends ResultFilter {
   @Override
   public boolean filterResult(long resultNode, SmallArrayBasedLongToDoubleMap[] socialProofs) {
     int size = socialProofTypes.length;
-    boolean keep = false;
     for (int i = 0; i < size; i++) {
       if (socialProofs[socialProofTypes[i]] != null) {
-        keep = true;
-        break;
+        return false;
       }
     }
-
-    return !keep;
+    return true;
   }
 }

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/GeneratorHelper.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/GeneratorHelper.java
@@ -17,6 +17,9 @@
 package com.twitter.graphjet.algorithms.counting;
 
 import com.twitter.graphjet.algorithms.NodeInfo;
+import com.twitter.graphjet.algorithms.RecommendationRequest;
+import com.twitter.graphjet.algorithms.RecommendationType;
+import com.twitter.graphjet.algorithms.counting.tweet.TopSecondDegreeByCountRequestForTweet;
 import com.twitter.graphjet.hashing.SmallArrayBasedLongToDoubleMap;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongList;
@@ -38,24 +41,41 @@ public final class GeneratorHelper {
    */
   public static Map<Byte, LongList> pickTopSocialProofs(
     SmallArrayBasedLongToDoubleMap[] socialProofs,
-    byte[] validSocialProofs,
     int maxSocialProofSize) {
 
     Map<Byte, LongList> results = new HashMap<>();
-    int length = validSocialProofs.length;
 
-    for (int i = 0; i < length; i++) {
-      SmallArrayBasedLongToDoubleMap socialProof = socialProofs[validSocialProofs[i]];
+    for (int i = 0; i < socialProofs.length; i++) {
+      SmallArrayBasedLongToDoubleMap socialProof = socialProofs[i];
       if (socialProof != null) {
         if (socialProof.size() > 1) {
           socialProof.sort();
         }
         socialProof.trim(maxSocialProofSize);
-        results.put(validSocialProofs[i], new LongArrayList(socialProof.keys()));
+        results.put((byte)i, new LongArrayList(socialProof.keys()));
       }
     }
 
     return results;
+  }
+
+  public static int getMinUserSocialProofSize(
+    TopSecondDegreeByCountRequestForTweet request,
+    RecommendationType recommendationType
+  ) {
+    return request.getMinUserSocialProofSizes().containsKey(recommendationType)
+      ? request.getMinUserSocialProofSizes().get(recommendationType)
+      : RecommendationRequest.DEFAULT_MIN_USER_SOCIAL_PROOF_SIZE;
+  }
+
+  public static int getMaxNumResults(
+    TopSecondDegreeByCountRequestForTweet request,
+    RecommendationType recommendationType
+  ) {
+    return request.getMaxNumResultsByType().containsKey(recommendationType)
+      ? Math.min(request.getMaxNumResultsByType().get(recommendationType),
+        RecommendationRequest.MAX_RECOMMENDATION_RESULTS)
+      : RecommendationRequest.DEFAULT_RECOMMENDATION_RESULTS;
   }
 
   public static void addResultToPriorityQueue(

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetMetadataRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetMetadataRecsGenerator.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.twitter.graphjet.algorithms.*;
+import com.twitter.graphjet.algorithms.counting.GeneratorHelper;
 import com.twitter.graphjet.algorithms.RecommendationInfo;
 import com.twitter.graphjet.hashing.SmallArrayBasedLongToDoubleMap;
 
@@ -116,17 +117,10 @@ public final class TopSecondDegreeByCountTweetMetadataRecsGenerator {
     }
 
     if (visitedMetadata != null) {
+      int maxNumResults = GeneratorHelper.getMaxNumResults(request, recommendationType);
+      int minUserSocialProofSize = GeneratorHelper.getMinUserSocialProofSize(request, recommendationType);
+
       List<TweetMetadataRecommendationInfo> filtered = null;
-
-      int minUserSocialProofSize =
-        request.getMinUserSocialProofSizes().containsKey(recommendationType)
-          ? request.getMinUserSocialProofSizes().get(recommendationType)
-          : RecommendationRequest.DEFAULT_MIN_USER_SOCIAL_PROOF_SIZE;
-
-      int maxNumResults = request.getMaxNumResultsByType().containsKey(recommendationType)
-        ? Math.min(request.getMaxNumResultsByType().get(recommendationType),
-        RecommendationRequest.MAX_RECOMMENDATION_RESULTS)
-        : RecommendationRequest.DEFAULT_RECOMMENDATION_RESULTS;
 
       for (Int2ObjectMap.Entry<TweetMetadataRecommendationInfo> entry
         : visitedMetadata.int2ObjectEntrySet()) {

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountUserRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountUserRecsGenerator.java
@@ -90,7 +90,6 @@ public final class TopSecondDegreeByCountUserRecsGenerator {
     TopSecondDegreeByCountRequestForUser request,
     PriorityQueue<NodeInfo> topNodes) {
     List<RecommendationInfo> outputResults = Lists.newArrayListWithCapacity(topNodes.size());
-    byte[] validSocialProofs = request.getSocialProofTypes();
     int maxNumSocialProofs = request.getMaxNumSocialProofs();
 
     while (!topNodes.isEmpty()) {
@@ -98,7 +97,6 @@ public final class TopSecondDegreeByCountUserRecsGenerator {
 
       Map<Byte, LongList> topSocialProofs = GeneratorHelper.pickTopSocialProofs(
         nodeInfo.getSocialProofs(),
-        validSocialProofs,
         maxNumSocialProofs);
 
       UserRecommendationInfo userRecs = new UserRecommendationInfo(

--- a/graphjet-demo/pom.xml
+++ b/graphjet-demo/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-demo</artifactId>
-  <version>1.0.6-SNAPSHOT</version>
+  <version>1.0.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Demo</name>
   <description>GraphJet is a real-time graph processing library: demo of core graph library</description>
@@ -26,12 +26,12 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.0.6-SNAPSHOT</version>
+      <version>1.0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-adapters</artifactId>
-      <version>1.0.6-SNAPSHOT</version>
+      <version>1.0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet</artifactId>
-  <version>1.0.6-SNAPSHOT</version>
+  <version>1.0.7-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>graphjet</name>


### PR DESCRIPTION
1) Only use valid social proof types when checking for minUserSocialProof for tweets

2) Return all the social proof types of the Recommendation. Do not filter only the valid social proof types.

For example, for minUserSocialProof = 2 and socialProofTypes=(Favorite, Tweet, Retweet), a candidate will not be generated if it only has 2 replies, but if it has 2 Favorites and a Reply then all those social proofs will be returned in the Recommendation.