### PR TITLE
Mrossides/authored by user

### DIFF
--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/SocialProofTypesFilter.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/SocialProofTypesFilter.java
@@ -36,10 +36,6 @@ public class SocialProofTypesFilter extends ResultFilter {
   }
 
   /**
-   * discard results without valid social proof types specified by clients
-   *
-   * @param resultNode is the result node to be checked
-   * @param socialProofs is the socialProofs of different types associated with the node
    * @return true if none of the specified socialProofTypes are present in the socialProofs map
    */
   @Override

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCount.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCount.java
@@ -18,7 +18,6 @@ package com.twitter.graphjet.algorithms.counting;
 
 import com.twitter.graphjet.algorithms.NodeInfo;
 import com.twitter.graphjet.algorithms.RecommendationAlgorithm;
-import com.twitter.graphjet.algorithms.RecommendationRequest;
 import com.twitter.graphjet.algorithms.RecommendationStats;
 import com.twitter.graphjet.bipartite.LeftIndexedMultiSegmentBipartiteGraph;
 import com.twitter.graphjet.bipartite.api.EdgeIterator;
@@ -45,8 +44,8 @@ public abstract class TopSecondDegreeByCount<Request extends TopSecondDegreeByCo
 
   // Static variables for better memory reuse. Avoids re-allocation on every request
   private final Long2ByteMap seenEdgesPerNode;
-  protected final LeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph;
   protected Long2ObjectMap<NodeInfo> visitedRightNodes;
+  protected final LeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph;
   protected final List<NodeInfo> nodeInfosAfterFiltering;
   protected final RecommendationStats topSecondDegreeByCountStats;
   protected final StatsReceiver statsReceiver;

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountRequest.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountRequest.java
@@ -30,7 +30,7 @@ public abstract class TopSecondDegreeByCountRequest extends RecommendationReques
   private final Long2DoubleMap leftSeedNodesWithWeight;
   private final int maxSocialProofTypeSize;
   private final ResultFilterChain resultFilterChain;
-  private final LongSet authoredByUsers;
+
   /**
    * @param queryNode                 is the query node for running TopSecondDegreeByCount
    * @param leftSeedNodesWithWeight   is the set of seed nodes and their weights to use for
@@ -46,13 +46,11 @@ public abstract class TopSecondDegreeByCountRequest extends RecommendationReques
     LongSet toBeFiltered,
     int maxSocialProofTypeSize,
     byte[] socialProofTypes,
-    LongSet authoredByUsers,
     ResultFilterChain resultFilterChain) {
     super(queryNode, toBeFiltered, socialProofTypes);
     this.leftSeedNodesWithWeight = leftSeedNodesWithWeight;
     this.maxSocialProofTypeSize = maxSocialProofTypeSize;
     this.resultFilterChain = resultFilterChain;
-    this.authoredByUsers = authoredByUsers;
   }
 
   public Long2DoubleMap getLeftSeedNodesWithWeight() {
@@ -61,10 +59,6 @@ public abstract class TopSecondDegreeByCountRequest extends RecommendationReques
 
   public int getMaxSocialProofTypeSize() {
     return maxSocialProofTypeSize;
-  }
-
-  public LongSet getAuthoredByUsers() {
-    return authoredByUsers;
   }
 
   public void resetFilters() {

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountRequest.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountRequest.java
@@ -30,6 +30,7 @@ public abstract class TopSecondDegreeByCountRequest extends RecommendationReques
   private final Long2DoubleMap leftSeedNodesWithWeight;
   private final int maxSocialProofTypeSize;
   private final ResultFilterChain resultFilterChain;
+  private final LongSet authoredByUsers;
   /**
    * @param queryNode                 is the query node for running TopSecondDegreeByCount
    * @param leftSeedNodesWithWeight   is the set of seed nodes and their weights to use for
@@ -45,11 +46,13 @@ public abstract class TopSecondDegreeByCountRequest extends RecommendationReques
     LongSet toBeFiltered,
     int maxSocialProofTypeSize,
     byte[] socialProofTypes,
+    LongSet authoredByUsers,
     ResultFilterChain resultFilterChain) {
     super(queryNode, toBeFiltered, socialProofTypes);
     this.leftSeedNodesWithWeight = leftSeedNodesWithWeight;
     this.maxSocialProofTypeSize = maxSocialProofTypeSize;
     this.resultFilterChain = resultFilterChain;
+    this.authoredByUsers = authoredByUsers;
   }
 
   public Long2DoubleMap getLeftSeedNodesWithWeight() {
@@ -60,6 +63,9 @@ public abstract class TopSecondDegreeByCountRequest extends RecommendationReques
     return maxSocialProofTypeSize;
   }
 
+  public LongSet getAuthoredByUsers() {
+    return authoredByUsers;
+  }
 
   public void resetFilters() {
     if (resultFilterChain != null) {

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountRequestForTweet.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountRequestForTweet.java
@@ -65,7 +65,8 @@ public class TopSecondDegreeByCountRequestForTweet extends TopSecondDegreeByCoun
     Map<RecommendationType, Integer> minUserSocialProofSizes,
     byte[] socialProofTypes,
     ResultFilterChain resultFilterChain,
-    Set<byte[]> socialProofTypeUnions
+    Set<byte[]> socialProofTypeUnions,
+    LongSet authoredByUsers
   ) {
     super(
       queryNode,
@@ -73,6 +74,7 @@ public class TopSecondDegreeByCountRequestForTweet extends TopSecondDegreeByCoun
       toBeFiltered,
       maxSocialProofTypeSize,
       socialProofTypes,
+      authoredByUsers,
       resultFilterChain);
     this.recommendationTypes = recommendationTypes;
     this.maxNumResultsByType = maxNumResultsByRecType;

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountRequestForTweet.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountRequestForTweet.java
@@ -34,6 +34,7 @@ public class TopSecondDegreeByCountRequestForTweet extends TopSecondDegreeByCoun
   private final int maxTweetSocialProofSize;
   private final Map<RecommendationType, Integer> minUserSocialProofSizes;
   private final Set<byte[]> socialProofTypeUnions;
+  private final LongSet authoredByUsers;
 
   /**
    * Construct a TopSecondDegreeByCount algorithm runner for tweet related recommendations.
@@ -74,7 +75,6 @@ public class TopSecondDegreeByCountRequestForTweet extends TopSecondDegreeByCoun
       toBeFiltered,
       maxSocialProofTypeSize,
       socialProofTypes,
-      authoredByUsers,
       resultFilterChain);
     this.recommendationTypes = recommendationTypes;
     this.maxNumResultsByType = maxNumResultsByRecType;
@@ -82,19 +82,34 @@ public class TopSecondDegreeByCountRequestForTweet extends TopSecondDegreeByCoun
     this.maxTweetSocialProofSize = maxTweetSocialProofSize;
     this.minUserSocialProofSizes = minUserSocialProofSizes;
     this.socialProofTypeUnions = socialProofTypeUnions;
+    this.authoredByUsers = authoredByUsers;
   }
 
   public Set<RecommendationType> getRecommendationTypes() {
     return recommendationTypes;
   }
 
-  public Map<RecommendationType, Integer> getMaxNumResultsByType() { return maxNumResultsByType; }
+  public Map<RecommendationType, Integer> getMaxNumResultsByType() {
+    return maxNumResultsByType;
+  }
 
-  public int getMaxUserSocialProofSize() { return maxUserSocialProofSize; }
+  public int getMaxUserSocialProofSize() {
+    return maxUserSocialProofSize;
+  }
 
-  public int getMaxTweetSocialProofSize() { return maxTweetSocialProofSize; }
+  public int getMaxTweetSocialProofSize() {
+    return maxTweetSocialProofSize;
+  }
 
-  public Map<RecommendationType, Integer> getMinUserSocialProofSizes() { return minUserSocialProofSizes; }
+  public Map<RecommendationType, Integer> getMinUserSocialProofSizes() {
+    return minUserSocialProofSizes;
+  }
 
-  public Set<byte[]> getSocialProofTypeUnions() { return socialProofTypeUnions; }
+  public Set<byte[]> getSocialProofTypeUnions() {
+    return socialProofTypeUnions;
+  }
+
+  public LongSet getAuthoredByUsers() {
+    return authoredByUsers;
+  }
 }

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountRequestForUser.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountRequestForUser.java
@@ -20,7 +20,9 @@ import com.twitter.graphjet.algorithms.RecommendationType;
 import com.twitter.graphjet.algorithms.ResultFilterChain;
 import com.twitter.graphjet.algorithms.counting.TopSecondDegreeByCountRequest;
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
+import it.unimi.dsi.fastutil.longs.LongArraySet;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.longs.LongSets;
 
 import java.util.Map;
 
@@ -58,7 +60,7 @@ public class TopSecondDegreeByCountRequestForUser extends TopSecondDegreeByCount
     long maxEdgeEngagementAgeInMillis,
     ResultFilterChain resultFilterChain) {
     super(queryNode, leftSeedNodesWithWeight, toBeFiltered, maxSocialProofTypeSize,
-        socialProofTypes, resultFilterChain);
+            socialProofTypes, new LongArraySet(), resultFilterChain);
     this.maxNumResults = maxNumResults;
     this.maxNumSocialProofs = maxNumSocialProofs;
     this.maxEdgeEngagementAgeInMillis = maxEdgeEngagementAgeInMillis;

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountRequestForUser.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountRequestForUser.java
@@ -20,7 +20,6 @@ import com.twitter.graphjet.algorithms.RecommendationType;
 import com.twitter.graphjet.algorithms.ResultFilterChain;
 import com.twitter.graphjet.algorithms.counting.TopSecondDegreeByCountRequest;
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
-import it.unimi.dsi.fastutil.longs.LongArraySet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 
 import java.util.Map;
@@ -59,7 +58,7 @@ public class TopSecondDegreeByCountRequestForUser extends TopSecondDegreeByCount
     long maxEdgeEngagementAgeInMillis,
     ResultFilterChain resultFilterChain) {
     super(queryNode, leftSeedNodesWithWeight, toBeFiltered, maxSocialProofTypeSize,
-            socialProofTypes, new LongArraySet(), resultFilterChain);
+        socialProofTypes, resultFilterChain);
     this.maxNumResults = maxNumResults;
     this.maxNumSocialProofs = maxNumSocialProofs;
     this.maxEdgeEngagementAgeInMillis = maxEdgeEngagementAgeInMillis;

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountRequestForUser.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountRequestForUser.java
@@ -22,7 +22,6 @@ import com.twitter.graphjet.algorithms.counting.TopSecondDegreeByCountRequest;
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
 import it.unimi.dsi.fastutil.longs.LongArraySet;
 import it.unimi.dsi.fastutil.longs.LongSet;
-import it.unimi.dsi.fastutil.longs.LongSets;
 
 import java.util.Map;
 

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountTest.java
@@ -92,6 +92,7 @@ public class TopSecondDegreeByCountTest {
       new RequestedSetFilter(new NullStatsReceiver())
     ));
     Set<byte[]> socialProofTypeUnions = new HashSet<>();
+    LongSet authoredByUsers = new LongOpenHashSet();
 
     TopSecondDegreeByCountRequestForTweet request = new TopSecondDegreeByCountRequestForTweet(
       queryNode,
@@ -105,7 +106,8 @@ public class TopSecondDegreeByCountTest {
       minUserSocialProofSizes,
       validSocialProofs,
       resultFilterChain,
-      socialProofTypeUnions
+      socialProofTypeUnions,
+      authoredByUsers
     );
 
     TopSecondDegreeByCountResponse response = new TopSecondDegreeByCountForTweet(
@@ -166,6 +168,7 @@ public class TopSecondDegreeByCountTest {
     ResultFilterChain resultFilterChain = new ResultFilterChain(Lists.<ResultFilter>newArrayList(
       new RequestedSetFilter(new NullStatsReceiver())
     ));
+    LongSet authoredByUsers = new LongOpenHashSet();
 
     TopSecondDegreeByCountRequestForTweet request = new TopSecondDegreeByCountRequestForTweet(
       queryNode,
@@ -179,7 +182,8 @@ public class TopSecondDegreeByCountTest {
       minUserSocialProofSizes,
       validSocialProofs,
       resultFilterChain,
-      socialProofTypeUnions
+      socialProofTypeUnions,
+      authoredByUsers
     );
 
     TopSecondDegreeByCountResponse response = new TopSecondDegreeByCountForTweet(
@@ -261,6 +265,7 @@ public class TopSecondDegreeByCountTest {
     ));
 
     Set<byte[]> socialProofTypeUnions = new HashSet<>();
+    LongSet authoredByUsers = new LongOpenHashSet();
 
     TopSecondDegreeByCountRequestForTweet request = new TopSecondDegreeByCountRequestForTweet(
       queryNode,
@@ -274,7 +279,8 @@ public class TopSecondDegreeByCountTest {
       minUserSocialProofSizes,
       validSocialProofs,
       resultFilterChain,
-      socialProofTypeUnions
+      socialProofTypeUnions,
+      authoredByUsers
     );
 
     TopSecondDegreeByCountResponse response = new TopSecondDegreeByCountForTweet(


### PR DESCRIPTION
Adding the ability to only generate candidates created by a specified set of authors. 

The author information is obtained from the graph edges; those edges exist in the graph for only 30 hours. Thus, we only get candidates who were created within 30 hours of the request. If we need to increase that, we will increase the number of segments in the graph.

We are also considering adding the author information in the graph in follow up changes.