### PR TITLE
Added AuthoredByUsersFilter

### DIFF
--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/AuthoredByUsersFilter.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/AuthoredByUsersFilter.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2016 Twitter. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.twitter.graphjet.algorithms;
+
+import com.twitter.graphjet.bipartite.api.EdgeIterator;
+import com.twitter.graphjet.bipartite.LeftIndexedMultiSegmentBipartiteGraph;
+import com.twitter.graphjet.hashing.SmallArrayBasedLongToDoubleMap;
+import com.twitter.graphjet.stats.StatsReceiver;
+import it.unimi.dsi.fastutil.longs.LongSet;
+
+public class AuthoredByUsersFilter extends ResultFilter {
+  private LongSet authoredByUsersNodes;
+
+  public AuthoredByUsersFilter(
+      LeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph,
+      LongSet authoredByUsers,
+      StatsReceiver statsReceiver) {
+    super(statsReceiver);
+    generateAuthoredByUsersNodes(leftIndexedBipartiteGraph, authoredByUsers);
+  }
+
+  private void generateAuthoredByUsersNodes(
+      LeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph,
+      LongSet authoredByUsers) {
+    for (long leftNode: authoredByUsers) {
+      EdgeIterator edgeIterator = leftIndexedBipartiteGraph.getLeftNodeEdges(leftNode);
+      if (edgeIterator == null) {
+        continue;
+      }
+
+      // Sequentially iterating through the latest MAX_EDGES_PER_NODE edges per node
+      int numEdgesPerNode = 0;
+      while (edgeIterator.hasNext() && numEdgesPerNode++ < RecommendationRequest.MAX_EDGES_PER_NODE) {
+        long rightNode = edgeIterator.nextLong();
+        byte edgeType = edgeIterator.currentEdgeType();
+        if (edgeType == RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE) {
+          authoredByUsersNodes.add(rightNode);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void resetFilter(RecommendationRequest request) {}
+
+  /**
+   * @return true if resultNode is not in the authoredByUsersNodes, which means that the
+   * resultNode was not authored by the specified users.
+   */
+  @Override
+  public boolean filterResult(long resultNode, SmallArrayBasedLongToDoubleMap[] socialProofs) {
+    return !authoredByUsersNodes.contains(resultNode);
+  }
+}

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/RecommendationRequest.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/RecommendationRequest.java
@@ -26,10 +26,11 @@ public abstract class RecommendationRequest {
   private final long queryNode;
   private final LongSet toBeFiltered;
   private final byte[] socialProofTypes;
-  public static final int MAX_RECOMMENDATION_RESULTS = 1000;
-  public static final int DEFAULT_RECOMMENDATION_RESULTS = 100;
-  public static final int DEFAULT_MIN_USER_SOCIAL_PROOF_SIZE = 1;
   public static final int AUTHOR_SOCIAL_PROOF_TYPE = 4;
+  public static final int DEFAULT_MIN_USER_SOCIAL_PROOF_SIZE = 1;
+  public static final int DEFAULT_RECOMMENDATION_RESULTS = 100;
+  public static final int MAX_EDGES_PER_NODE = 500;
+  public static final int MAX_RECOMMENDATION_RESULTS = 1000;
 
   protected RecommendationRequest(
     long queryNode,

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/TweetAuthorFilter.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/TweetAuthorFilter.java
@@ -21,23 +21,24 @@ import com.twitter.graphjet.bipartite.api.EdgeIterator;
 import com.twitter.graphjet.bipartite.LeftIndexedMultiSegmentBipartiteGraph;
 import com.twitter.graphjet.hashing.SmallArrayBasedLongToDoubleMap;
 import com.twitter.graphjet.stats.StatsReceiver;
+import it.unimi.dsi.fastutil.longs.LongArraySet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 
-public class AuthoredByUsersFilter extends ResultFilter {
-  private LongSet authoredByUsersNodes;
+public class TweetAuthorFilter extends ResultFilter {
+  private LongSet authoredTweets = new LongArraySet();
 
-  public AuthoredByUsersFilter(
+  public TweetAuthorFilter(
       LeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph,
-      LongSet authoredByUsers,
+      LongSet tweetAuthors,
       StatsReceiver statsReceiver) {
     super(statsReceiver);
-    generateAuthoredByUsersNodes(leftIndexedBipartiteGraph, authoredByUsers);
+    generateAuthoredByUsersNodes(leftIndexedBipartiteGraph, tweetAuthors);
   }
 
   private void generateAuthoredByUsersNodes(
       LeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph,
-      LongSet authoredByUsers) {
-    for (long leftNode: authoredByUsers) {
+      LongSet tweetAuthors) {
+    for (long leftNode: tweetAuthors) {
       EdgeIterator edgeIterator = leftIndexedBipartiteGraph.getLeftNodeEdges(leftNode);
       if (edgeIterator == null) {
         continue;
@@ -49,7 +50,7 @@ public class AuthoredByUsersFilter extends ResultFilter {
         long rightNode = edgeIterator.nextLong();
         byte edgeType = edgeIterator.currentEdgeType();
         if (edgeType == RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE) {
-          authoredByUsersNodes.add(rightNode);
+          authoredTweets.add(rightNode);
         }
       }
     }
@@ -64,6 +65,6 @@ public class AuthoredByUsersFilter extends ResultFilter {
    */
   @Override
   public boolean filterResult(long resultNode, SmallArrayBasedLongToDoubleMap[] socialProofs) {
-    return !authoredByUsersNodes.contains(resultNode);
+    return !authoredTweets.contains(resultNode);
   }
 }

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCount.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCount.java
@@ -18,6 +18,7 @@ package com.twitter.graphjet.algorithms.counting;
 
 import com.twitter.graphjet.algorithms.NodeInfo;
 import com.twitter.graphjet.algorithms.RecommendationAlgorithm;
+import com.twitter.graphjet.algorithms.RecommendationRequest;
 import com.twitter.graphjet.algorithms.RecommendationStats;
 import com.twitter.graphjet.bipartite.LeftIndexedMultiSegmentBipartiteGraph;
 import com.twitter.graphjet.bipartite.api.EdgeIterator;
@@ -40,7 +41,6 @@ public abstract class TopSecondDegreeByCount<Request extends TopSecondDegreeByCo
   implements RecommendationAlgorithm<Request, Response> {
 
   protected static final Logger LOG = LoggerFactory.getLogger("graph");
-  protected static final int MAX_EDGES_PER_NODE = 500;
 
   // Static variables for better memory reuse. Avoids re-allocation on every request
   private final LeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph;
@@ -137,16 +137,16 @@ public abstract class TopSecondDegreeByCount<Request extends TopSecondDegreeByCo
   private void collectRightNodeInfo(Request request) {
     for (Long2DoubleMap.Entry entry: request.getLeftSeedNodesWithWeight().long2DoubleEntrySet()) {
       long leftNode = entry.getLongKey();
-      double weight = entry.getDoubleValue();
-      int numEdgesPerNode = 0;
       EdgeIterator edgeIterator = leftIndexedBipartiteGraph.getLeftNodeEdges(leftNode);
-      seenEdgesPerNode.clear();
-
       if (edgeIterator == null) {
         continue;
       }
+
+      int numEdgesPerNode = 0;
+      double weight = entry.getDoubleValue();
+      seenEdgesPerNode.clear();
       // Sequentially iterating through the latest MAX_EDGES_PER_NODE edges per node
-      while (edgeIterator.hasNext() && numEdgesPerNode++ < MAX_EDGES_PER_NODE) {
+      while (edgeIterator.hasNext() && numEdgesPerNode++ < RecommendationRequest.MAX_EDGES_PER_NODE) {
         long rightNode = edgeIterator.nextLong();
         byte edgeType = edgeIterator.currentEdgeType();
 


### PR DESCRIPTION
Adding the ability to only generate candidates created by a specified set of authors.

The author information is obtained from the graph edges; those edges exist in the graph for only 30 hours. Thus, we only get candidates who were created within 30 hours of the request. If we need to increase that, we will increase the number of segments in the graph.

We are also considering adding the author information in the graph in follow up changes.