### PR TITLE
Mrossides/fix keyset in small array

### DIFF
--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.12-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-adapters</artifactId>
-  <version>1.0.11-SNAPSHOT</version>
+  <version>1.0.12-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Adapters</name>
   <description>GraphJet is a real-time graph processing library: adapters for other graph systems</description>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.0.11-SNAPSHOT</version>
+      <version>1.0.12-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>

--- a/graphjet-core/pom.xml
+++ b/graphjet-core/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.12-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-core</artifactId>
-  <version>1.0.11-SNAPSHOT</version>
+  <version>1.0.12-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Core</name>
   <description>GraphJet is a real-time graph processing library: core graph library and recommendation algorithms</description>

--- a/graphjet-core/src/main/java/com/twitter/graphjet/hashing/SmallArrayBasedLongToDoubleMap.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/hashing/SmallArrayBasedLongToDoubleMap.java
@@ -177,7 +177,9 @@ public class SmallArrayBasedLongToDoubleMap {
    * Note: Use this function with caution since it is linear to ADD_KEYS_TO_SET_THRESHOLD.
    */
   public boolean contains(long key) {
-    if (size < ADD_KEYS_TO_SET_THRESHOLD) {
+    // The size might have reached the ADD_KEYS_TO_SET_THRESHOLD, but we may have not inserted
+    // a new key yet. Therefore, we need to also check if the size is equal to that threshold.
+    if (size <= ADD_KEYS_TO_SET_THRESHOLD) {
       for (int i = 0; i < size; i++) {
         if (key == keys[i]) {
           return true;

--- a/graphjet-demo/pom.xml
+++ b/graphjet-demo/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.12-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-demo</artifactId>
-  <version>1.0.11-SNAPSHOT</version>
+  <version>1.0.12-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Demo</name>
   <description>GraphJet is a real-time graph processing library: demo of core graph library</description>
@@ -26,12 +26,12 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.0.11-SNAPSHOT</version>
+      <version>1.0.12-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-adapters</artifactId>
-      <version>1.0.11-SNAPSHOT</version>
+      <version>1.0.12-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet</artifactId>
-  <version>1.0.11-SNAPSHOT</version>
+  <version>1.0.12-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>graphjet</name>


### PR DESCRIPTION
Fixed the contains function of SmallArrayBasedLongToDoubleMap.java.

This was causing NullPointer exceptions when keySet.contains was called on a null keySet.