### PR TITLE
Jjiang/remove tweetonly filter

### DIFF
--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.0.19-SNAPSHOT</version>
+    <version>1.0.20-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-adapters</artifactId>
-  <version>1.0.19-SNAPSHOT</version>
+  <version>1.0.20-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Adapters</name>
   <description>GraphJet is a real-time graph processing library: adapters for other graph systems</description>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.0.19-SNAPSHOT</version>
+      <version>1.0.20-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>

--- a/graphjet-core/pom.xml
+++ b/graphjet-core/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.0.19-SNAPSHOT</version>
+    <version>1.0.20-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-core</artifactId>
-  <version>1.0.19-SNAPSHOT</version>
+  <version>1.0.20-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Core</name>
   <description>GraphJet is a real-time graph processing library: core graph library and recommendation algorithms</description>

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetMetadataRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetMetadataRecsGenerator.java
@@ -23,9 +23,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.twitter.graphjet.algorithms.*;
-import com.twitter.graphjet.algorithms.counting.GeneratorHelper;
+import com.twitter.graphjet.algorithms.NodeInfo;
 import com.twitter.graphjet.algorithms.RecommendationInfo;
+import com.twitter.graphjet.algorithms.RecommendationType;
+import com.twitter.graphjet.algorithms.TweetIDMask;
+import com.twitter.graphjet.algorithms.counting.GeneratorHelper;
 import com.twitter.graphjet.hashing.SmallArrayBasedLongToDoubleMap;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -138,10 +138,9 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
     int minUserSocialProofSize) {
     int length = validSocialProofs.length;
     long authorId = getAuthorId(socialProofs);
-    boolean isLessThan = false;
 
     for (int i = 0; i < length; i++) {
-      // Skip tweet social proof because its size can be only one
+      // Skip tweet author social proof because its size can be only one
       if (validSocialProofs[i] == RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE) {
         continue;
       }
@@ -151,12 +150,11 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
           minUserSocialProofThreshold += 1;
         }
         if (socialProofs[validSocialProofs[i]].size() < minUserSocialProofThreshold) {
-          isLessThan = true;
-          break;
+          return true;
         }
       }
     }
-    return isLessThan;
+    return false;
   }
 
   // Return the authorId of the Tweet, if the author is in the leftSeedNodesWithWeight; otherwise, return -1.

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -54,10 +54,6 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
 
     // handling specific rules of tweet recommendations
     for (NodeInfo nodeInfo : nodeInfoList) {
-      // do not return tweet recommendations with only Tweet social proofs.
-      if (isTweetSocialProofOnly(nodeInfo.getSocialProofs())) {
-        continue;
-      }
       // do not return if size of each social proof is less than minUserSocialProofSize.
       if (isLessThanMinUserSocialProofSize(nodeInfo.getSocialProofs(), validSocialProofs, minUserSocialProofSize) &&
         // do not return if size of each social proof union is less than minUserSocialProofSize.

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -65,7 +65,6 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
           nodeInfo.getSocialProofs(), minUserSocialProofSize, request.getSocialProofTypeUnions())) {
         continue;
       }
-
       GeneratorHelper.addResultToPriorityQueue(topResults, nodeInfo, maxNumResults);
     }
 

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -17,7 +17,10 @@
 
 package com.twitter.graphjet.algorithms.counting.tweet;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Set;
 
 import com.google.common.collect.Lists;
 
@@ -28,6 +31,7 @@ import com.twitter.graphjet.algorithms.RecommendationType;
 import com.twitter.graphjet.algorithms.TweetIDMask;
 import com.twitter.graphjet.algorithms.counting.GeneratorHelper;
 import com.twitter.graphjet.hashing.SmallArrayBasedLongToDoubleMap;
+
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 
@@ -61,6 +65,7 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
           nodeInfo.getSocialProofs(), minUserSocialProofSize, request.getSocialProofTypeUnions())) {
         continue;
       }
+
       GeneratorHelper.addResultToPriorityQueue(topResults, nodeInfo, maxNumResults);
     }
 
@@ -134,27 +139,25 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
     int minUserSocialProofSize) {
     int length = validSocialProofs.length;
     long authorId = getAuthorId(socialProofs);
+    boolean isLessThan = false;
+
     for (int i = 0; i < length; i++) {
+      // Skip tweet social proof because its size can be only one
+      if (validSocialProofs[i] == RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE) {
+        continue;
+      }
       if (socialProofs[validSocialProofs[i]] != null) {
         int minUserSocialProofThreshold = minUserSocialProofSize;
         if (authorId != -1 && socialProofs[validSocialProofs[i]].contains(authorId)) {
           minUserSocialProofThreshold += 1;
         }
-        if (socialProofs[validSocialProofs[i]].size() >= minUserSocialProofThreshold) {
-          return false;
+        if (socialProofs[validSocialProofs[i]].size() < minUserSocialProofThreshold) {
+          isLessThan = true;
+          break;
         }
       }
     }
-    return true;
-  }
-
-  private static boolean isTweetSocialProofOnly(SmallArrayBasedLongToDoubleMap[] socialProofs) {
-    for (int i = 0; i < socialProofs.length; i++) {
-      if (i != RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE && socialProofs[i] != null) {
-        return false;
-      }
-    }
-    return true;
+    return isLessThan;
   }
 
   // Return the authorId of the Tweet, if the author is in the leftSeedNodesWithWeight; otherwise, return -1.

--- a/graphjet-demo/pom.xml
+++ b/graphjet-demo/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.0.19-SNAPSHOT</version>
+    <version>1.0.20-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-demo</artifactId>
-  <version>1.0.19-SNAPSHOT</version>
+  <version>1.0.20-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Demo</name>
   <description>GraphJet is a real-time graph processing library: demo of core graph library</description>
@@ -26,12 +26,12 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.0.19-SNAPSHOT</version>
+      <version>1.0.20-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-adapters</artifactId>
-      <version>1.0.19-SNAPSHOT</version>
+      <version>1.0.20-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet</artifactId>
-  <version>1.0.19-SNAPSHOT</version>
+  <version>1.0.20-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>graphjet</name>


### PR DESCRIPTION
Previously, when social proof is Tweet only, GraphJet will not return tweet recommendations. This rb fixes this behavior.