### PR TITLE
Jjiang/add big long array

### DIFF
--- a/graphjet-core/src/main/java/com/twitter/graphjet/hashing/BigLongArray.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/hashing/BigLongArray.java
@@ -1,0 +1,58 @@
+package com.twitter.graphjet.hashing;
+
+/**
+ * Allows manipulating a data structure as a long array. A client can store entries in an
+ * arbitrary position in this array, and increment positions as they normally would for a regular
+ * one-dimensional array. All operations here are expected to be constant time lookups.
+ */
+public interface BigLongArray {
+  /**
+   * Adds an entry to the array at a specific desired position. Note that this would over-write any
+   * existing value.
+   *
+   * @param entry     is the entry to add
+   * @param position  is the position where to put the entry
+   */
+  void addEntry(long entry, int position);
+
+  /**
+   * Fetches the stored entry at a position.
+   *
+   * @param position  is the position to look at
+   * @return the stored entry.
+   */
+  long getEntry(int position);
+
+  /**
+   * Increments the stored entry at a position by delta.
+   *
+   * @param position  is the position to look at
+   * @param delta  is the change in the value associated with the position
+   * @return null entry if the position is not already filled, or the new value otherwise.
+   */
+  long incrementEntry(int position, long delta);
+
+  /**
+   * Batch add array elements in {@link BigLongArray}.
+   *
+   * @param src the source array
+   * @param srcPos the starting position in the source array
+   * @param desPos the starting position in {@link BigLongArray}
+   * @param length the number of array elements to be copied
+   * @param updateStats whether to update internal stats or not
+   */
+  void arrayCopy(long[] src, int srcPos, int desPos, int length, boolean updateStats);
+
+  /**
+   * The fill percentage is the percentage of memory allocated that is being occupied. This should
+   * be very cheap to get and will be exported as a stat counter.
+   *
+   * @return the fill percentage
+   */
+  double getFillPercentage();
+
+  /**
+   * Resets all the memory. Doesn't actually free it, but resets it.
+   */
+  void reset();
+}

--- a/graphjet-core/src/main/java/com/twitter/graphjet/hashing/BigLongArray.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/hashing/BigLongArray.java
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2017 Twitter. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package com.twitter.graphjet.hashing;
 
 /**

--- a/graphjet-core/src/main/java/com/twitter/graphjet/hashing/ShardedBigIntArray.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/hashing/ShardedBigIntArray.java
@@ -33,7 +33,7 @@ import com.twitter.graphjet.stats.StatsReceiver;
  * are accessed.
  * <p>There is a little bit of extra computational cost associated with sharding, namely that we need
  * to convert positions to shards and offsets. To make this cost negligible, we enforce that shard
- * lengths are powers of 2, which implies that conversations are bit operations. This does make the
+ * lengths are powers of 2, which implies that conversions are bit operations. This does make the
  * array size a bit larger than desired, but the memory overhead is generally small.</p>
  *
  * <p>This class is thread-safe even though it does not do any locking: it achieves this by leveraging

--- a/graphjet-core/src/main/java/com/twitter/graphjet/hashing/ShardedBigLongArray.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/hashing/ShardedBigLongArray.java
@@ -79,7 +79,7 @@ public class ShardedBigLongArray implements BigLongArray {
     }
   }
 
-  // Making the int array preferred size be 256KB ~ size of L2 cache
+  // Making the long array preferred size be 512KB ~ 2 * size of L2 cache
   public static final int PREFERRED_EDGES_PER_SHARD = 1 << 16;
   private static final double SHARD_GROWTH_FACTOR = 1.1;
 

--- a/graphjet-core/src/main/java/com/twitter/graphjet/hashing/ShardedBigLongArray.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/hashing/ShardedBigLongArray.java
@@ -1,0 +1,278 @@
+package com.twitter.graphjet.hashing;
+
+import java.util.Arrays;
+
+import com.google.common.base.Preconditions;
+
+import com.twitter.graphjet.stats.Counter;
+import com.twitter.graphjet.stats.StatsReceiver;
+
+/**
+ * <p>This class implements a large array as an array of arrays that are sharded. There are two
+ * benefits advantage of this implementation over a large one-dimensional array:</p>
+ * 1) Since the array is allocated shard-by-shard, we expect better GC performance for large arrays
+ * as each shard can be allocated/collected separately
+ * 2) Accessing entries requires loading much less data in L1 cache since only the relevant "shards"
+ * are accessed.
+ * <p>There is a little bit of extra computational cost associated with sharding, namely that we need
+ * to convert positions to shards and offsets. To make this cost negligible, we enforce that shard
+ * lengths are powers of 2, which implies that conversations are bit operations. This does make the
+ * array size a bit larger than desired, but the memory overhead is generally small.</p>
+ *
+ * <p>This class is thread-safe even though it does not do any locking: it achieves this by leveraging
+ * the assumptions stated below and using a "memory barrier" between writes and reads to sync
+ * updates.</p>
+ *
+ * <p>Here are the client assumptions needed to enable lock-free read/writes:</p>
+ * 1. There is a SINGLE writer thread -- this is extremely important as we don't lock during writes.
+ * 2. Readers are OK reading stale data, i.e. if even if a reader thread arrives after the writer
+ * thread started doing a write, the update is NOT guaranteed to be available to it unless the
+ * update has finished.
+ *
+ * <p>This class enables lock-free read/writes by guaranteeing the following:</p>
+ * 1. The writes that are done are always "safe", i.e. in no time during the writing do they leave
+ * things in a state such that a reader would either encounter an exception or do wrong
+ * computation.
+ * 2. After a write is done, it is explicitly "published" such that a reader that arrives after
+ * the published write it would see updated data.
+ *
+ * <p>The way this works is as follows: suppose we have some linked objects X, Y and Z that need to be
+ * maintained in a consistent state. First, our setup ensures that the reader is _only_ allowed to
+ * access these in a linear manner as follows: read X -> read Y -> read Z. Then, we ensure that the
+ * writer behavior is to write (safe, atomic) updates to each of these in the exact opposite order:
+ * write Z --flush--&gt; write Y --flush--&gt; write X.</p>
+ *
+ * <p>Note that the flushing ensures that if a reader sees Y then it _must_ also see the updated Z,
+ * and if sees X then it _must_ also see the updated Y and Z. Further, each update itself is safe.
+ * For instance, a reader can safely access an updated Z even if X and Y are not updated since the
+ * updated information will only be accessible through the updated X and Y (the converse though is
+ * NOT true). Together, this ensures that the reader accesses to the objects are always consistent
+ * with each other and safe to access by the reader.</p>
+ */
+public class ShardedBigLongArray implements BigLongArray {
+  /**
+   * <p>This class encapsulates ALL the state that will be accessed by a reader (refer to the X, Y, Z
+   * comment above). The final members are used to guarantee visibility to other threads without
+   * synchronization/using volatile.</p>
+   *
+   * <p>From 'Java Concurrency in practice' by Brian Goetz, p. 349:</p>
+   *
+   * <blockquote>"Initialization safety guarantees that for properly
+   * constructed objects, all threads will see the correct values of
+   * final fields that were set by the constructor, regardless of
+   * how the object is published. Further, any variables that can be
+   * reached through a final field of a properly constructed object
+   * (such as the elements of a final array or the contents of a
+   * HashMap referenced by a final field) are also guaranteed to be
+   * visible to other threads."</blockquote>
+   */
+  public static final class ReaderAccessibleInfo {
+    public final long[][] array;
+
+    /**
+     * A new instance is immediately visible to the readers due to publication safety.
+     *
+     * @param array contains all the array in the pool
+     */
+    public ReaderAccessibleInfo(long[][] array) {
+      this.array = array;
+    }
+  }
+
+  // Making the int array preferred size be 256KB ~ size of L2 cache
+  public static final int PREFERRED_EDGES_PER_SHARD = 1 << 16;
+  private static final double SHARD_GROWTH_FACTOR = 1.1;
+
+  // This is is the only reader-accessible data
+  protected ReaderAccessibleInfo readerAccessibleInfo;
+
+  private final long nullEntry;
+  private final int shardLength;
+  private final int shardLengthNumBits;
+  private final int offsetMask;
+  private final Counter numArrayEntries;
+
+  private int numShards;
+  private int numAllocatedSlotsForEntries;
+  private int numStoredEntries;
+
+  /**
+   * Reserves the needed memory for a {@link ShardedBigLongArray}, and initializes most of the
+   * objects that would be needed for this graph. Note that actual memory would be allocated as
+   * needed, and the amount of memory needed will increase if more nodes arrive than expected.
+   *
+   * @param numExpectedEntries  is the expected number of nodes that will be added into this pool.
+   *                            The actual number of nodes can be larger and the pool will expand
+   *                            itself to fit them till we hit the limit of max array size in Java.
+   * @param minShardSize        is the minimum size of each shard. Internally, we round up to a
+   *                            power of 2
+   * @param nullEntry           is the default return value when a position has not been filled is
+   *                            asked for
+   * @param statsReceiver       is used to update storage stats
+   */
+  public ShardedBigLongArray(
+    int numExpectedEntries,
+    int minShardSize,
+    long nullEntry,
+    StatsReceiver statsReceiver) {
+    int shardSize = Math.max(PREFERRED_EDGES_PER_SHARD, minShardSize);
+    // We round shards up to be a power of two
+    this.shardLengthNumBits =
+      Math.max(Integer.numberOfTrailingZeros(Integer.highestOneBit(shardSize - 1) << 1), 4);
+    this.shardLength = 1 << shardLengthNumBits;
+    this.offsetMask = shardLength - 1;
+    this.nullEntry = nullEntry;
+    StatsReceiver scopedStatsReceiver = statsReceiver.scope("ShardedBigLongArray");
+    this.numArrayEntries = scopedStatsReceiver.counter("numArrayEntries");
+    numShards = Math.max(numExpectedEntries >> shardLengthNumBits, 1);
+    Preconditions.checkArgument(numShards * shardLength < Integer.MAX_VALUE,
+      "Exceeded the max storage capacity for ShardedBigLongArray");
+    readerAccessibleInfo = new ReaderAccessibleInfo(new long[numShards][]);
+    this.numAllocatedSlotsForEntries = shardLength;
+    allocateMemoryForShard(0);
+  }
+
+  /**
+   * Synchronization comment: this method works fine without needing synchronization between the
+   * writer and the readers due to the wrapping of the arrays in ReaderAccessibleInfo. See
+   * the publication safety comment in those objects.
+   */
+  private void expandArray(int shardId) {
+    int newNumShards = Math.max((int) Math.ceil(numShards * SHARD_GROWTH_FACTOR), shardId + 1);
+    Preconditions.checkArgument(newNumShards * shardLength < Integer.MAX_VALUE,
+      "Exceeded the max storage capacity for ShardedBigIntArray");
+    long[][] newArray = new long[newNumShards][];
+    // Important: the arraycopy assumes that the size of each shard remains same
+    System.arraycopy(readerAccessibleInfo.array, 0, newArray, 0, readerAccessibleInfo.array.length);
+    // This flushes all the reader-accessible data *together* to all threads: the readers are safe
+    // as long as they reference the wrapper object since the data stays the same
+    readerAccessibleInfo = new ReaderAccessibleInfo(newArray);
+    numShards = newNumShards;
+  }
+
+  private void allocateMemoryForShard(int shardId) {
+    long[] newShard = new long[shardLength];
+    if (nullEntry != 0) {
+      Arrays.fill(newShard, nullEntry);
+    }
+    readerAccessibleInfo.array[shardId] = newShard;
+    numAllocatedSlotsForEntries += shardLength;
+  }
+
+  @Override
+  public void addEntry(long entry, int position) {
+    int shard = position >> shardLengthNumBits;
+    int offset = position & offsetMask;
+    // we may need more shards
+    if (shard >= numShards) {
+      expandArray(shard);
+    }
+    // the shard's memory may not have been allocated yet
+    if (readerAccessibleInfo.array[shard] == null) {
+      allocateMemoryForShard(shard);
+    }
+    // (Jerry To Do) long writes are not necessarily atomic in JVM
+    readerAccessibleInfo.array[shard][offset] = entry;
+    numStoredEntries++;
+    numArrayEntries.incr();
+  }
+
+  @Override
+  public void arrayCopy(long[] src, int srcPos, int desPos, int length, boolean updateStats) {
+    int shard = desPos >> shardLengthNumBits;
+    int offset = desPos & offsetMask;
+    // we may need more shards
+    if (shard >= numShards) {
+      expandArray(shard);
+    }
+
+    // the shard's memory may not have been allocated yet
+    if (readerAccessibleInfo.array[shard] == null) {
+      allocateMemoryForShard(shard);
+    }
+
+    if (offset + length <= shardLength) {
+      System.arraycopy(
+        src,
+        srcPos,
+        readerAccessibleInfo.array[shard],
+        offset,
+        length
+      );
+    } else {
+      System.arraycopy(
+        src,
+        srcPos,
+        readerAccessibleInfo.array[shard],
+        offset,
+        shardLength - offset
+      );
+
+      int deltaLength = shardLength - offset;
+
+      // if current shard does not have enough space to hold all elements in this batch, add them to
+      // the next shard(s) recursively
+      arrayCopy(
+        src,
+        srcPos + deltaLength,
+        desPos + deltaLength,
+        length - deltaLength,
+        false /*updateStats*/
+      );
+    }
+
+    if (updateStats) {
+      numStoredEntries += length;
+      numArrayEntries.incr(length);
+    }
+  }
+
+  @Override
+  public long getEntry(int position) {
+    int shard = position >> shardLengthNumBits;
+    int offset = position & offsetMask;
+    // we may need more shards
+    if ((shard >= numShards) || (readerAccessibleInfo.array[shard] == null)) {
+      return nullEntry;
+    }
+    return readerAccessibleInfo.array[shard][offset];
+  }
+
+  @Override
+  public long incrementEntry(int position, long delta) {
+    int shard = position >> shardLengthNumBits;
+    int offset = position & offsetMask;
+    // we may need more shards
+    if ((shard >= numShards) || (readerAccessibleInfo.array[shard] == null)) {
+      return nullEntry;
+    }
+
+    readerAccessibleInfo.array[shard][offset] += delta;
+    return readerAccessibleInfo.array[shard][offset];
+  }
+
+  public long[] getShard(int position) {
+    int shard = position >> shardLengthNumBits;
+
+    return readerAccessibleInfo.array[shard];
+  }
+
+  public int getShardOffset(int position) {
+    return position & offsetMask;
+  }
+
+  @Override
+  public double getFillPercentage() {
+    return 100.0 * numStoredEntries / (double) numAllocatedSlotsForEntries;
+  }
+
+  @Override
+  public void reset() {
+    numStoredEntries = 0;
+    for (int i = 0; i < numShards; i++) {
+      if (readerAccessibleInfo.array[i] != null) {
+        Arrays.fill(readerAccessibleInfo.array[i], nullEntry);
+      }
+    }
+  }
+}

--- a/graphjet-core/src/main/java/com/twitter/graphjet/hashing/ShardedBigLongArray.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/hashing/ShardedBigLongArray.java
@@ -16,7 +16,7 @@ import com.twitter.graphjet.stats.StatsReceiver;
  * are accessed.
  * <p>There is a little bit of extra computational cost associated with sharding, namely that we need
  * to convert positions to shards and offsets. To make this cost negligible, we enforce that shard
- * lengths are powers of 2, which implies that conversations are bit operations. This does make the
+ * lengths are powers of 2, which implies that conversions are bit operations. This does make the
  * array size a bit larger than desired, but the memory overhead is generally small.</p>
  *
  * <p>This class is thread-safe even though it does not do any locking: it achieves this by leveraging

--- a/graphjet-core/src/test/java/com/twitter/graphjet/hashing/ShardedBigLongArrayTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/hashing/ShardedBigLongArrayTest.java
@@ -1,0 +1,95 @@
+package com.twitter.graphjet.hashing;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import com.twitter.graphjet.stats.NullStatsReceiver;
+
+public class ShardedBigLongArrayTest {
+  @Test
+  public void testSequentialReadWrites() {
+    int maxNumNodes = 1 << 16;
+    int shardSize = 1 << 10;
+    long nullEntry = -1L;
+    ShardedBigLongArray shardedBigLongArray = new ShardedBigLongArray(
+      maxNumNodes / 16, shardSize, nullEntry, new NullStatsReceiver());
+
+    for (int i = 0; i < maxNumNodes; i++) {
+      long entry = i * 2;
+      assertEquals(nullEntry, shardedBigLongArray.getEntry(i));
+      shardedBigLongArray.addEntry(entry, i);
+      assertEquals(entry, shardedBigLongArray.getEntry(i));
+    }
+
+    for (int i = 0; i < maxNumNodes; i++) {
+      assertEquals(nullEntry, shardedBigLongArray.getEntry(maxNumNodes + i));
+    }
+  }
+
+
+  @Test
+  public void testIntegerRandomReadWrites() {
+    int maxNumNodes = 1 << 16;
+    int shardSize = 1 << 10;
+    long nullEntry = -1L;
+    List<Integer> indexList = Lists.newArrayListWithCapacity(maxNumNodes);
+    ShardedBigLongArray shardedBigLongArray = new ShardedBigLongArray(
+      maxNumNodes / 16, shardSize, nullEntry, new NullStatsReceiver());
+
+    for (int i = 0; i < maxNumNodes; i++) {
+      indexList.add(i);
+    }
+
+    Collections.shuffle(indexList);
+    for (Integer index : indexList) {
+      long entry = index * 2;
+      assertEquals(nullEntry, shardedBigLongArray.getEntry(index));
+      shardedBigLongArray.addEntry(entry, index);
+      assertEquals(entry, shardedBigLongArray.getEntry(index));
+    }
+
+    for (int i = 0; i < maxNumNodes; i++) {
+      assertEquals(i * 2, shardedBigLongArray.getEntry(i));
+    }
+
+    for (int i = 0; i < maxNumNodes; i++) {
+      assertEquals(nullEntry, shardedBigLongArray.getEntry(maxNumNodes + i));
+    }
+  }
+
+  @Test
+  public void testLongRandomReadWrites() {
+    int maxNumNodes = 1 << 16;
+    int shardSize = 1 << 10;
+    long nullEntry = -1L;
+    List<Integer> indexList = Lists.newArrayListWithCapacity(maxNumNodes);
+    ShardedBigLongArray shardedBigLongArray = new ShardedBigLongArray(
+      maxNumNodes / 16, shardSize, nullEntry, new NullStatsReceiver());
+
+    for (int i = 0; i < maxNumNodes; i++) {
+      indexList.add(i);
+    }
+
+    Collections.shuffle(indexList);
+    for (Integer index : indexList) {
+      long entry = index * Integer.MAX_VALUE;
+      assertEquals(nullEntry, shardedBigLongArray.getEntry(index));
+      shardedBigLongArray.addEntry(entry, index);
+      assertEquals(entry, shardedBigLongArray.getEntry(index));
+    }
+
+    for (int i = 0; i < maxNumNodes; i++) {
+      assertEquals(i * Integer.MAX_VALUE, shardedBigLongArray.getEntry(i));
+    }
+
+    for (int i = 0; i < maxNumNodes; i++) {
+      assertEquals(nullEntry, shardedBigLongArray.getEntry(maxNumNodes + i));
+    }
+  }
+}

--- a/graphjet-core/src/test/java/com/twitter/graphjet/hashing/ShardedBigLongArrayTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/hashing/ShardedBigLongArrayTest.java
@@ -17,7 +17,7 @@ public class ShardedBigLongArrayTest {
     int maxNumNodes = 1 << 16;
     int shardSize = 1 << 10;
     long nullEntry = -1L;
-    ShardedBigLongArray shardedBigLongArray = new ShardedBigLongArray(
+    BigLongArray shardedBigLongArray = new ShardedBigLongArray(
       maxNumNodes / 16, shardSize, nullEntry, new NullStatsReceiver());
 
     for (int i = 0; i < maxNumNodes; i++) {
@@ -39,7 +39,7 @@ public class ShardedBigLongArrayTest {
     int shardSize = 1 << 10;
     long nullEntry = -1L;
     List<Integer> indexList = Lists.newArrayListWithCapacity(maxNumNodes);
-    ShardedBigLongArray shardedBigLongArray = new ShardedBigLongArray(
+    BigLongArray shardedBigLongArray = new ShardedBigLongArray(
       maxNumNodes / 16, shardSize, nullEntry, new NullStatsReceiver());
 
     for (int i = 0; i < maxNumNodes; i++) {
@@ -69,7 +69,7 @@ public class ShardedBigLongArrayTest {
     int shardSize = 1 << 10;
     long nullEntry = -1L;
     List<Integer> indexList = Lists.newArrayListWithCapacity(maxNumNodes);
-    ShardedBigLongArray shardedBigLongArray = new ShardedBigLongArray(
+    BigLongArray shardedBigLongArray = new ShardedBigLongArray(
       maxNumNodes / 16, shardSize, nullEntry, new NullStatsReceiver());
 
     for (int i = 0; i < maxNumNodes; i++) {


### PR DESCRIPTION
Add BigLongArray and ShardedBigLongArray to store long metadata per edge. The interface and implementation are mostly copied from BigIntArray and ShardedBigIntArray. 

Java Generics do not support primitives and that is why I do not use Generics here.  