### PR TITLE
User/Moment recommendations should use NodeMetadata graph

### DIFF
--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.1.3-SNAPSHOT</version>
+      <version>1.1.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>

--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-adapters</artifactId>
-  <version>1.1.3-SNAPSHOT</version>
+  <version>1.1.4-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Adapters</name>
   <description>GraphJet is a real-time graph processing library: adapters for other graph systems</description>

--- a/graphjet-core/pom.xml
+++ b/graphjet-core/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-core</artifactId>
-  <version>1.1.3-SNAPSHOT</version>
+  <version>1.1.4-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Core</name>
   <description>GraphJet is a real-time graph processing library: core graph library and recommendation algorithms</description>

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/moment/TopSecondDegreeByCountForMoment.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/moment/TopSecondDegreeByCountForMoment.java
@@ -22,7 +22,7 @@ import com.twitter.graphjet.algorithms.NodeInfo;
 import com.twitter.graphjet.algorithms.RecommendationInfo;
 import com.twitter.graphjet.algorithms.counting.TopSecondDegreeByCount;
 import com.twitter.graphjet.algorithms.counting.TopSecondDegreeByCountResponse;
-import com.twitter.graphjet.bipartite.LeftIndexedPowerLawMultiSegmentBipartiteGraph;
+import com.twitter.graphjet.bipartite.NodeMetadataLeftIndexedMultiSegmentBipartiteGraph;
 import com.twitter.graphjet.bipartite.api.EdgeIterator;
 import com.twitter.graphjet.stats.StatsReceiver;
 
@@ -32,7 +32,7 @@ public class TopSecondDegreeByCountForMoment extends
   /**
    * Construct a TopSecondDegreeByCount algorithm runner for moment recommendations.
    * @param leftIndexedBipartiteGraph is the
-   *                                  {@link LeftIndexedPowerLawMultiSegmentBipartiteGraph}
+   *                                  {@link NodeMetadataLeftIndexedMultiSegmentBipartiteGraph}
    *                                  to run TopSecondDegreeByCountForMoment on
    * @param expectedNodesToHit        is an estimate of how many nodes can be hit in
    *                                  TopSecondDegreeByCountForMoment. This is purely for allocating needed
@@ -40,7 +40,7 @@ public class TopSecondDegreeByCountForMoment extends
    * @param statsReceiver             tracks the internal stats
    */
   public TopSecondDegreeByCountForMoment(
-    LeftIndexedPowerLawMultiSegmentBipartiteGraph leftIndexedBipartiteGraph,
+      NodeMetadataLeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph,
     int expectedNodesToHit,
     StatsReceiver statsReceiver) {
     super(leftIndexedBipartiteGraph, expectedNodesToHit, statsReceiver);

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountForUser.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountForUser.java
@@ -22,7 +22,7 @@ import com.twitter.graphjet.algorithms.NodeInfo;
 import com.twitter.graphjet.algorithms.RecommendationInfo;
 import com.twitter.graphjet.algorithms.counting.TopSecondDegreeByCount;
 import com.twitter.graphjet.algorithms.counting.TopSecondDegreeByCountResponse;
-import com.twitter.graphjet.bipartite.LeftIndexedPowerLawMultiSegmentBipartiteGraph;
+import com.twitter.graphjet.bipartite.NodeMetadataLeftIndexedMultiSegmentBipartiteGraph;
 import com.twitter.graphjet.bipartite.api.EdgeIterator;
 import com.twitter.graphjet.stats.StatsReceiver;
 
@@ -32,7 +32,7 @@ public class TopSecondDegreeByCountForUser extends
   /**
    * Construct a TopSecondDegreeByCount algorithm runner for user related recommendations.
    * @param leftIndexedBipartiteGraph is the
-   *                                  {@link LeftIndexedPowerLawMultiSegmentBipartiteGraph}
+   *                                  {@link NodeMetadataLeftIndexedMultiSegmentBipartiteGraph}
    *                                  to run TopSecondDegreeByCountForUser on
    * @param expectedNodesToHit        is an estimate of how many nodes can be hit in
    *                                  TopSecondDegreeByCountForUser. This is purely for allocating needed
@@ -40,7 +40,7 @@ public class TopSecondDegreeByCountForUser extends
    * @param statsReceiver             tracks the internal stats
    */
   public TopSecondDegreeByCountForUser(
-    LeftIndexedPowerLawMultiSegmentBipartiteGraph leftIndexedBipartiteGraph,
+      NodeMetadataLeftIndexedMultiSegmentBipartiteGraph leftIndexedBipartiteGraph,
     int expectedNodesToHit,
     StatsReceiver statsReceiver) {
     super(leftIndexedBipartiteGraph, expectedNodesToHit, statsReceiver);

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountForMomentTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountForMomentTest.java
@@ -38,7 +38,7 @@ import com.twitter.graphjet.algorithms.filters.ResultFilterChain;
 import com.twitter.graphjet.algorithms.counting.moment.MomentRecommendationInfo;
 import com.twitter.graphjet.algorithms.counting.moment.TopSecondDegreeByCountForMoment;
 import com.twitter.graphjet.algorithms.counting.moment.TopSecondDegreeByCountRequestForMoment;
-import com.twitter.graphjet.bipartite.LeftIndexedPowerLawMultiSegmentBipartiteGraph;
+import com.twitter.graphjet.bipartite.NodeMetadataLeftIndexedMultiSegmentBipartiteGraph;
 import com.twitter.graphjet.stats.NullStatsReceiver;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleArrayMap;
@@ -140,8 +140,8 @@ public class TopSecondDegreeByCountForMomentTest {
     List<TopSecondDegreeByCountRecommendationInfo> expectedTopResults,
     RecommendationStats expectedTopSecondDegreeByCountStats
   ) throws Exception {
-    LeftIndexedPowerLawMultiSegmentBipartiteGraph bipartiteGraph =
-      BipartiteGraphTestHelper.buildSmallTestLeftIndexedPowerLawMultiSegmentBipartiteGraphWithEdgeTypes();
+    NodeMetadataLeftIndexedMultiSegmentBipartiteGraph bipartiteGraph =
+      BipartiteGraphTestHelper.buildSmallTestNodeMetadataLeftIndexedMultiSegmentBipartiteGraphWithEdgeTypes();
 
     long queryNode = 1;
     int maxSocialProofSize = 4;

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountForUserTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountForUserTest.java
@@ -38,7 +38,7 @@ import com.twitter.graphjet.algorithms.filters.ResultFilterChain;
 import com.twitter.graphjet.algorithms.counting.user.TopSecondDegreeByCountForUser;
 import com.twitter.graphjet.algorithms.counting.user.TopSecondDegreeByCountRequestForUser;
 import com.twitter.graphjet.algorithms.counting.user.UserRecommendationInfo;
-import com.twitter.graphjet.bipartite.LeftIndexedPowerLawMultiSegmentBipartiteGraph;
+import com.twitter.graphjet.bipartite.NodeMetadataLeftIndexedMultiSegmentBipartiteGraph;
 import com.twitter.graphjet.stats.NullStatsReceiver;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleArrayMap;
@@ -170,8 +170,8 @@ public class TopSecondDegreeByCountForUserTest {
     List<UserRecommendationInfo> expectedTopResults,
     RecommendationStats expectedTopSecondDegreeByCountStats
   ) throws Exception {
-    LeftIndexedPowerLawMultiSegmentBipartiteGraph bipartiteGraph =
-      BipartiteGraphTestHelper.buildSmallTestLeftIndexedPowerLawMultiSegmentBipartiteGraphWithEdgeTypes();
+    NodeMetadataLeftIndexedMultiSegmentBipartiteGraph bipartiteGraph =
+      BipartiteGraphTestHelper.buildSmallTestNodeMetadataLeftIndexedMultiSegmentBipartiteGraphWithEdgeTypes();
 
     long queryNode = 1;
     int maxSocialProofSize = 4;

--- a/graphjet-demo/pom.xml
+++ b/graphjet-demo/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.4-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-demo</artifactId>
-  <version>1.1.3-SNAPSHOT</version>
+  <version>1.1.4-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Demo</name>
   <description>GraphJet is a real-time graph processing library: demo of core graph library</description>
@@ -26,12 +26,12 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.1.3-SNAPSHOT</version>
+      <version>1.1.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-adapters</artifactId>
-      <version>1.1.3-SNAPSHOT</version>
+      <version>1.1.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet</artifactId>
-  <version>1.1.3-SNAPSHOT</version>
+  <version>1.1.4-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>graphjet</name>


### PR DESCRIPTION
This request changes the interface of User and Moment recommendation pipelines to accept NodeMetadataLeftIndexedMultiSegmentBipartiteGraph. This allows user and moment recommendations to utilize the edge metadata.