### PR TITLE
Add "Unfavorite" edge indexing into tweet counting algorithms

### DIFF
--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.1.11-SNAPSHOT</version>
+    <version>1.1.12-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-adapters</artifactId>
-  <version>1.1.11-SNAPSHOT</version>
+  <version>1.1.12-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Adapters</name>
   <description>GraphJet is a real-time graph processing library: adapters for other graph systems</description>

--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.1.11-SNAPSHOT</version>
+      <version>1.1.12-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>

--- a/graphjet-core/pom.xml
+++ b/graphjet-core/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.1.10</version>
+    <version>1.1.12-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-core</artifactId>
-  <version>1.1.10-jimdebug-3</version>
+  <version>1.1.12-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Core</name>
   <description>GraphJet is a real-time graph processing library: core graph library and recommendation algorithms</description>

--- a/graphjet-core/pom.xml
+++ b/graphjet-core/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.1.11-SNAPSHOT</version>
+    <version>1.1.10</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-core</artifactId>
-  <version>1.1.11-SNAPSHOT</version>
+  <version>1.1.10-jimdebug-3</version>
   <packaging>jar</packaging>
   <name>GraphJet Core</name>
   <description>GraphJet is a real-time graph processing library: core graph library and recommendation algorithms</description>

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/ConnectingUsersWithMetadata.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/ConnectingUsersWithMetadata.java
@@ -28,6 +28,11 @@ public class ConnectingUsersWithMetadata {
   }
 
   @Override
+  public String toString() {
+    return "connectingUsers = " + connectingUsers.toString() + ", metadata = " + metadata.toString();
+  }
+
+  @Override
   public boolean equals(Object obj) {
     if (obj == null) {
       return false;

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/NodeInfo.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/NodeInfo.java
@@ -22,10 +22,12 @@ import com.google.common.base.Objects;
 import com.twitter.graphjet.hashing.SmallArrayBasedLongToDoubleMap;
 
 /**
- * This class contains information about a node that's a potential recommendation.
+ * This class contains information about a node that's a potential recommendation, by collecting the
+ * engagements (social proofs) from other nodes. An example usage is to aggregate the
+ * different social proof engagements on a tweet from different users.
  */
 public class NodeInfo implements Comparable<NodeInfo> {
-  private final long value;
+  private final long nodeId;
   private int[][] nodeMetadata;
   private double weight;
   private int numVisits;
@@ -35,13 +37,13 @@ public class NodeInfo implements Comparable<NodeInfo> {
   /**
    * Creates an instance for a node.
    *
-   * @param value        is the node value
+   * @param nodeId        is the node nodeId
    * @param nodeMetadata is the metadata arrays associated with each node, such as hashtags and urls
    * @param weight       is the initial weight
    * @param maxSocialProofTypeSize is the max social proof types to keep
    */
-  public NodeInfo(long value, int[][] nodeMetadata, double weight, int maxSocialProofTypeSize) {
-    this.value = value;
+  public NodeInfo(long nodeId, int[][] nodeMetadata, double weight, int maxSocialProofTypeSize) {
+    this.nodeId = nodeId;
     this.nodeMetadata = nodeMetadata;
     this.weight = weight;
     this.numVisits = 1;
@@ -51,20 +53,20 @@ public class NodeInfo implements Comparable<NodeInfo> {
   /**
    * Creates an instance for a node and sets empty node meta data in the node.
    *
-   * @param value  is the node value
+   * @param nodeId  is the node nodeId
    * @param weight is the initial weight
    * @param maxSocialProofTypeSize is the max social proof types to keep
    */
-  public NodeInfo(long value, double weight, int maxSocialProofTypeSize) {
-    this.value = value;
+  public NodeInfo(long nodeId, double weight, int maxSocialProofTypeSize) {
+    this.nodeId = nodeId;
     this.nodeMetadata = EMPTY_NODE_META_DATA;
     this.weight = weight;
     this.numVisits = 1;
     this.socialProofs = new SmallArrayBasedLongToDoubleMap[maxSocialProofTypeSize];
   }
 
-  public long getValue() {
-    return value;
+  public long getNodeId() {
+    return nodeId;
   }
 
   public double getWeight() {
@@ -94,22 +96,22 @@ public class NodeInfo implements Comparable<NodeInfo> {
   }
 
   /**
-   * Attempts to add the given node as social proof. Note that the node itself may or may not be
-   * added depending on the nodeWeight and the current status of the social proof, with the idea
+   * Attempts to add the given socialProofId as social proof. Note that the socialProofId itself may or may not be
+   * added depending on the socialProofWeight and the current status of the social proof, with the idea
    * being to maintain the "best" social proof.
    *
-   * @param node        is the node to attempt to add
-   * @param edgeType    is the edge type between the social proof and the recommendation
-   * @param edgeMetadata is the edge metadata between the social proof and the recommendation
-   * @param nodeWeight  is the nodeWeight of the node
-   * @return true of the node was added, false if not
+   * @param socialProofId     is the socialProofId to attempt to add
+   * @param edgeType          is the edge type between the social proof and the recommendation
+   * @param edgeMetadata      is the edge metadata between the social proof and the recommendation
+   * @param socialProofWeight is the socialProofWeight of the socialProofId
+   * @return true of the socialProofId was added, false if not
    */
-  public boolean addToSocialProof(long node, byte edgeType, long edgeMetadata, double nodeWeight) {
+  public boolean addToSocialProof(long socialProofId, byte edgeType, long edgeMetadata, double socialProofWeight) {
     if (socialProofs[edgeType] == null) {
       socialProofs[edgeType] = new SmallArrayBasedLongToDoubleMap();
     }
 
-    socialProofs[edgeType].put(node, nodeWeight, edgeMetadata);
+    socialProofs[edgeType].put(socialProofId, socialProofWeight, edgeMetadata);
     return true;
   }
 
@@ -123,7 +125,7 @@ public class NodeInfo implements Comparable<NodeInfo> {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(value, weight);
+    return Objects.hashCode(nodeId, weight);
   }
 
   @Override
@@ -141,14 +143,14 @@ public class NodeInfo implements Comparable<NodeInfo> {
     NodeInfo other = (NodeInfo) obj;
 
     return
-      Objects.equal(getValue(), other.getValue())
+      Objects.equal(getNodeId(), other.getNodeId())
         && Objects.equal(getWeight(), other.getWeight());
   }
 
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
-      .add("value", value)
+      .add("nodeId", nodeId)
       .add("weight", weight)
       .add("socialProofs", socialProofs)
       .toString();

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCount.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCount.java
@@ -221,7 +221,7 @@ public abstract class TopSecondDegreeByCount<Request extends TopSecondDegreeByCo
   private void filterNodeInfo(Request request) {
     int numFilteredNodes = 0;
     for (NodeInfo nodeInfo : visitedRightNodes.values()) {
-      if (request.filterResult(nodeInfo.getValue(), nodeInfo.getSocialProofs())) {
+      if (request.filterResult(nodeInfo.getNodeId(), nodeInfo.getSocialProofs())) {
         numFilteredNodes++;
         continue;
       }

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/moment/TopSecondDegreeByCountMomentRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/moment/TopSecondDegreeByCountMomentRecsGenerator.java
@@ -65,7 +65,7 @@ public final class TopSecondDegreeByCountMomentRecsGenerator {
       );
 
       MomentRecommendationInfo momentRecs = new MomentRecommendationInfo(
-        nodeInfo.getValue(),
+        nodeInfo.getNodeId(),
         nodeInfo.getWeight(),
         topSocialProofs);
       outputResults.add(momentRecs);

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountForTweet.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountForTweet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Twitter. All rights reserved.
+ * Copyright 2018 Twitter. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,8 +80,10 @@ public class TopSecondDegreeByCountForTweet extends
         return timeStampFromTweetId;
       case 7:  // QUOTE
         return RecentTweetFilter.timeStampFromTweetId(edgeMetadata);
+      case 8:  // UNFAVORITE
+        return edgeMetadata;
       default:
-        throw new IllegalStateException("Invalid EdgeType in getEdgeTimeStampInMillis");
+        throw new IllegalStateException("Invalid EdgeType in getEdgeTimeStampInMillis: " + edgeType);
     }
   }
 

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetMetadataRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetMetadataRecsGenerator.java
@@ -52,7 +52,7 @@ public final class TopSecondDegreeByCountTweetMetadataRecsGenerator {
         recommendationInfo.addToTweetSocialProofs(
           (byte) k,
           socialProofsByType[k],
-          TWEET_ID_MASK.restore(nodeInfo.getValue()),
+          TWEET_ID_MASK.restore(nodeInfo.getNodeId()),
           maxUserSocialProofSize,
           maxTweetSocialProofSize
         );

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -16,6 +16,7 @@
 
 package com.twitter.graphjet.algorithms.counting.tweet;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -68,26 +69,27 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
 
     SmallArrayBasedLongToDoubleMap newFavSocialProofs = new SmallArrayBasedLongToDoubleMap();
     double weightToRemove = 0;
-    boolean isNodeInfoModified = false;
 
-    for (long unfavUser: unfavSocialProofs.keys()) {
-      for (int i = 0; i < favSocialProofs.size(); i++) {
-        long favUser = favSocialProofs.keys()[i];
-        double favWeight = favSocialProofs.values()[i];
-        if (unfavUser == favUser) {
-          isNodeInfoModified = true;
-          weightToRemove += favWeight * 2; // *2 to take into account of both fav and unfav edge
-          continue;
-        }
+    for (int i = 0; i < favSocialProofs.size(); i++) {
+      long favUser = favSocialProofs.keys()[i];
+      double favWeight = favSocialProofs.values()[i];
+
+      if (unfavSocialProofs.contains(favUser)) {
+        weightToRemove += favSocialProofs.values()[i];
+      } else {
         newFavSocialProofs.put(favUser, favWeight, favSocialProofs.metadata()[i]);
       }
+    }
+
+    for (int i = 0; i < unfavSocialProofs.size(); i++) {
+      weightToRemove += unfavSocialProofs.values()[i];
     }
 
     // Add the filtered Favorite social proofs, and remove the Unfavorite social proofs from nodeInfo
     nodeInfo.setWeight(nodeInfo.getWeight() - weightToRemove);
     socialProofs[FavoriteSocialProofType] = (newFavSocialProofs.size() != 0) ? newFavSocialProofs : null;
     socialProofs[UnfavoriteSocialProofType] = null;
-    return isNodeInfoModified;
+    return true;
   }
 
   /**

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -42,6 +42,10 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
   private TopSecondDegreeByCountTweetRecsGenerator() {
   }
 
+  private static boolean isUnfavoriteTypeSupported(NodeInfo nodeInfo) {
+    return UnfavoriteSocialProofType < nodeInfo.getSocialProofs().length;
+  }
+
   /**
    * Given a nodeInfo containing the collection of all social proofs on a tweet, remove the
    * Favorite social proofs that also have Unfavorite counterparts, and deduct the weight of the
@@ -50,10 +54,8 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
    */
   private static void removeUnfavoriteSocialProofs(NodeInfo nodeInfo) {
     SmallArrayBasedLongToDoubleMap[] socialProofs = nodeInfo.getSocialProofs();
-    SmallArrayBasedLongToDoubleMap unfavSocialProofs =
-        socialProofs[UnfavoriteSocialProofType];
-    SmallArrayBasedLongToDoubleMap favSocialProofs =
-        socialProofs[FavoriteSocialProofType];
+    SmallArrayBasedLongToDoubleMap unfavSocialProofs = socialProofs[UnfavoriteSocialProofType];
+    SmallArrayBasedLongToDoubleMap favSocialProofs = socialProofs[FavoriteSocialProofType];
 
     if (unfavSocialProofs == null || favSocialProofs == null) {
       return;
@@ -110,9 +112,11 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
 
     // handling specific rules of tweet recommendations
     for (NodeInfo nodeInfo : nodeInfoList) {
-      removeUnfavoriteSocialProofs(nodeInfo);
-      if (!nodeInfoHasValidSocialProofs(nodeInfo)) {
-        continue;
+      if (isUnfavoriteTypeSupported(nodeInfo)) {
+        removeUnfavoriteSocialProofs(nodeInfo);
+        if (!nodeInfoHasValidSocialProofs(nodeInfo)) {
+          continue;
+        }
       }
 
       // do not return if size of each social proof or size of each social proof union

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -69,26 +69,27 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
 
     SmallArrayBasedLongToDoubleMap newFavSocialProofs = new SmallArrayBasedLongToDoubleMap();
     double weightToRemove = 0;
-    boolean isNodeInfoModified = false;
 
-    for (long unfavUser: unfavSocialProofs.keys()) {
-      for (int i = 0; i < favSocialProofs.size(); i++) {
-        long favUser = favSocialProofs.keys()[i];
-        double favWeight = favSocialProofs.values()[i];
-        if (unfavUser == favUser) {
-          isNodeInfoModified = true;
-          weightToRemove += favWeight * 2; // *2 to take into account of both fav and unfav edge
-          continue;
-        }
+    for (int i = 0; i < favSocialProofs.size(); i++) {
+      long favUser = favSocialProofs.keys()[i];
+      double favWeight = favSocialProofs.values()[i];
+
+      if (unfavSocialProofs.contains(favUser)) {
+        weightToRemove += favSocialProofs.values()[i];
+      } else {
         newFavSocialProofs.put(favUser, favWeight, favSocialProofs.metadata()[i]);
       }
+    }
+
+    for (int i = 0; i < unfavSocialProofs.size(); i++) {
+      weightToRemove += unfavSocialProofs.values()[i];
     }
 
     // Add the filtered Favorite social proofs, and remove the Unfavorite social proofs from nodeInfo
     nodeInfo.setWeight(nodeInfo.getWeight() - weightToRemove);
     socialProofs[FavoriteSocialProofType] = (newFavSocialProofs.size() != 0) ? newFavSocialProofs : null;
     socialProofs[UnfavoriteSocialProofType] = null;
-    return isNodeInfoModified;
+    return true;
   }
 
   /**

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -74,7 +74,7 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
       NodeInfo nodeInfo = topResults.poll();
       outputResults.add(
         new TweetRecommendationInfo(
-          TWEET_ID_MASK.restore(nodeInfo.getValue()),
+          TWEET_ID_MASK.restore(nodeInfo.getNodeId()),
           nodeInfo.getWeight(),
           GeneratorHelper.pickTopSocialProofs(nodeInfo.getSocialProofs()),
           nodeInfo.getNodeMetadata(TweetFeature.TWEET_FEATURE.getValue())));

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -50,36 +50,45 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
   /**
    * Given a nodeInfo containing the collection of all social proofs on a tweet, remove the
    * Favorite social proofs that also have Unfavorite counterparts, and deduct the weight of the
-   * nodeInfo accordingly.
-   * The Unfavorite social proofs will always be reset to null.
+   * nodeInfo accordingly. The Unfavorite social proofs will always be reset to null.
+   *
+   * @return true if the nodInfo has been modified, i.e. have Unfavorited removed, false otherwise.
    */
-  private static void removeUnfavoriteSocialProofs(NodeInfo nodeInfo) {
+  private static boolean removeUnfavoriteSocialProofs(NodeInfo nodeInfo) {
+    if (!isUnfavoriteTypeSupported(nodeInfo)) {
+      return false;
+    }
+
     SmallArrayBasedLongToDoubleMap[] socialProofs = nodeInfo.getSocialProofs();
     SmallArrayBasedLongToDoubleMap unfavSocialProofs = socialProofs[UnfavoriteSocialProofType];
     SmallArrayBasedLongToDoubleMap favSocialProofs = socialProofs[FavoriteSocialProofType];
 
     if (unfavSocialProofs == null || favSocialProofs == null) {
-      return;
+      return false;
     }
 
     SmallArrayBasedLongToDoubleMap newFavSocialProofs = new SmallArrayBasedLongToDoubleMap();
     double weightToRemove = 0;
+    boolean isNodeInfoModified = false;
 
-    for (int i = 0; i < favSocialProofs.size(); i++) {
-      long favUser = favSocialProofs.keys()[i];
-      double favWeight = favSocialProofs.values()[i];
-      long favMetadata = favSocialProofs.metadata()[i];
-
-      if (unfavSocialProofs.contains(favUser)) {
-        weightToRemove += favWeight * 2; // *2 to take into account of both fav and unfav edge
-        continue;
+    for (long unfavUser: unfavSocialProofs.keys()) {
+      for (int i = 0; i < favSocialProofs.size(); i++) {
+        long favUser = favSocialProofs.keys()[i];
+        double favWeight = favSocialProofs.values()[i];
+        if (unfavUser == favUser) {
+          isNodeInfoModified = true;
+          weightToRemove += favWeight * 2; // *2 to take into account of both fav and unfav edge
+          continue;
+        }
+        newFavSocialProofs.put(favUser, favWeight, favSocialProofs.metadata()[i]);
       }
-      newFavSocialProofs.put(favUser, favWeight, favMetadata);
     }
 
+    // Add the filtered Favorite social proofs, and remove the Unfavorite social proofs from nodeInfo
     nodeInfo.setWeight(nodeInfo.getWeight() - weightToRemove);
     socialProofs[FavoriteSocialProofType] = (newFavSocialProofs.size() != 0) ? newFavSocialProofs : null;
     socialProofs[UnfavoriteSocialProofType] = null;
+    return isNodeInfoModified;
   }
 
   /**
@@ -113,11 +122,10 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
 
     // handling specific rules of tweet recommendations
     for (NodeInfo nodeInfo : nodeInfoList) {
-      if (isUnfavoriteTypeSupported(nodeInfo)) {
-        removeUnfavoriteSocialProofs(nodeInfo);
-        if (!nodeInfoHasValidSocialProofs(nodeInfo)) {
-          continue;
-        }
+      // Remove unfavorited edges, and discard the nodeInfo if it no longer has social proofs
+      boolean isNodeModified = removeUnfavoriteSocialProofs(nodeInfo);
+      if (isNodeModified && !nodeInfoHasValidSocialProofs(nodeInfo)) {
+        continue;
       }
 
       // do not return if size of each social proof is less than minUserSocialProofSize.

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -43,6 +43,10 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
   private TopSecondDegreeByCountTweetRecsGenerator() {
   }
 
+  private static boolean isUnfavoriteTypeSupported(NodeInfo nodeInfo) {
+    return UnfavoriteSocialProofType < nodeInfo.getSocialProofs().length;
+  }
+
   /**
    * Given a nodeInfo containing the collection of all social proofs on a tweet, remove the
    * Favorite social proofs that also have Unfavorite counterparts, and deduct the weight of the
@@ -51,10 +55,8 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
    */
   private static void removeUnfavoriteSocialProofs(NodeInfo nodeInfo) {
     SmallArrayBasedLongToDoubleMap[] socialProofs = nodeInfo.getSocialProofs();
-    SmallArrayBasedLongToDoubleMap unfavSocialProofs =
-        socialProofs[UnfavoriteSocialProofType];
-    SmallArrayBasedLongToDoubleMap favSocialProofs =
-        socialProofs[FavoriteSocialProofType];
+    SmallArrayBasedLongToDoubleMap unfavSocialProofs = socialProofs[UnfavoriteSocialProofType];
+    SmallArrayBasedLongToDoubleMap favSocialProofs = socialProofs[FavoriteSocialProofType];
 
     if (unfavSocialProofs == null || favSocialProofs == null) {
       return;
@@ -111,9 +113,11 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
 
     // handling specific rules of tweet recommendations
     for (NodeInfo nodeInfo : nodeInfoList) {
-      removeUnfavoriteSocialProofs(nodeInfo);
-      if (!nodeInfoHasValidSocialProofs(nodeInfo)) {
-        continue;
+      if (isUnfavoriteTypeSupported(nodeInfo)) {
+        removeUnfavoriteSocialProofs(nodeInfo);
+        if (!nodeInfoHasValidSocialProofs(nodeInfo)) {
+          continue;
+        }
       }
 
       // do not return if size of each social proof is less than minUserSocialProofSize.

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountUserRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/user/TopSecondDegreeByCountUserRecsGenerator.java
@@ -64,7 +64,7 @@ public final class TopSecondDegreeByCountUserRecsGenerator {
         nodeInfo.getSocialProofs());
 
       UserRecommendationInfo userRecs = new UserRecommendationInfo(
-        nodeInfo.getValue(),
+        nodeInfo.getNodeId(),
         nodeInfo.getWeight(),
         topSocialProofs);
       outputResults.add(userRecs);

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/salsa/SalsaSelectResults.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/salsa/SalsaSelectResults.java
@@ -71,7 +71,7 @@ public class SalsaSelectResults<T extends LeftIndexedBipartiteGraph> {
     int numFilteredNodes = 0;
     for (NodeInfo nodeInfo : salsaInternalState.getVisitedRightNodes().values()) {
       if (salsaInternalState.getSalsaRequest().filterResult(
-        nodeInfo.getValue(),
+        nodeInfo.getNodeId(),
         nodeInfo.getSocialProofs())
       ) {
         numFilteredNodes++;
@@ -91,7 +91,7 @@ public class SalsaSelectResults<T extends LeftIndexedBipartiteGraph> {
       NodeInfo nodeInfo = topResults.poll();
       outputResults.add(
         new TweetRecommendationInfo(
-          TWEET_ID_MASK.restore(nodeInfo.getValue()),
+          TWEET_ID_MASK.restore(nodeInfo.getNodeId()),
           nodeInfo.getWeight(),
           pickTopSocialProofs(nodeInfo.getSocialProofs(), validSocialProofs)));
     }

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/BipartiteGraphTestHelper.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/BipartiteGraphTestHelper.java
@@ -205,7 +205,7 @@ public final class BipartiteGraphTestHelper {
   }
 
   /**
-   * Builds a small test graph with special edge type Favorite (1) and Unfavorite (8). This test
+   * Builds a small test graph with special edge types Favorite (1) and Unfavorite (8). This test
    * graph is built specifically for the counting algorithms on tweets.
    * The resultant graph after removing unfavorited edges consists of the following engagements:
    * tweet1, tweet2, tweet3: no engagement
@@ -240,8 +240,8 @@ public final class BipartiteGraphTestHelper {
 
     NodeMetadataLeftIndexedMultiSegmentBipartiteGraph nodeMetadataGraph =
       new NodeMetadataLeftIndexedPowerLawMultiSegmentBipartiteGraph(
-        3,
         10,
+        5,
         10,
         10,
         2.0,

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/BipartiteGraphTestHelper.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/BipartiteGraphTestHelper.java
@@ -213,6 +213,8 @@ public final class BipartiteGraphTestHelper {
    * tweet5: user2, user3 Favorite
    * tweet6: user2 Retweet
    * tweet7: user1 Favorite, user3 Retweet
+   * tweet8: user4 Favorite
+   * tweet9: user3, user4 Favorite
    *
    * @return a small test {@link NodeMetadataLeftIndexedMultiSegmentBipartiteGraph}
    */
@@ -224,6 +226,7 @@ public final class BipartiteGraphTestHelper {
     long user2 = 2;
     long user3 = 3;
     long user4 = 4;
+    long user5 = 5;
 
     long tweet1 = 1;
     long tweet2 = 2;
@@ -233,6 +236,7 @@ public final class BipartiteGraphTestHelper {
     long tweet6 = 6;
     long tweet7 = 7;
     long tweet8 = 8;
+    long tweet9 = 9;
 
     NodeMetadataLeftIndexedMultiSegmentBipartiteGraph nodeMetadataGraph =
       new NodeMetadataLeftIndexedPowerLawMultiSegmentBipartiteGraph(
@@ -277,6 +281,15 @@ public final class BipartiteGraphTestHelper {
     nodeMetadataGraph.addEdge(user4, tweet8, favoriteEdge, 0L, nodeMeta, nodeMeta);
     nodeMetadataGraph.addEdge(user1, tweet8, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
     nodeMetadataGraph.addEdge(user3, tweet8, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+
+    nodeMetadataGraph.addEdge(user1, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user2, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user3, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user4, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user5, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet9, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user2, tweet9, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user5, tweet9, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
 
     return nodeMetadataGraph;
   }

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/BipartiteGraphTestHelper.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/BipartiteGraphTestHelper.java
@@ -205,6 +205,83 @@ public final class BipartiteGraphTestHelper {
   }
 
   /**
+   * Builds a small test graph with special edge type Favorite (1) and Unfavorite (8). This test
+   * graph is built specifically for the counting algorithms on tweets.
+   * The resultant graph after removing unfavorited edges consists of the following engagements:
+   * tweet1, tweet2, tweet3: no engagement
+   * tweet4: user1 Favorite
+   * tweet5: user2, user3 Favorite
+   * tweet6: user2 Retweet
+   * tweet7: user1 Favorite, user3 Retweet
+   *
+   * @return a small test {@link NodeMetadataLeftIndexedMultiSegmentBipartiteGraph}
+   */
+  public static NodeMetadataLeftIndexedMultiSegmentBipartiteGraph
+  buildTestNodeMetadataLeftIndexedMultiSegmentBipartiteGraphWithUnfavorite(
+    byte favoriteEdge, byte unfavoriteEdge, byte retweetEdge
+  ) {
+    long user1 = 1;
+    long user2 = 2;
+    long user3 = 3;
+    long user4 = 4;
+
+    long tweet1 = 1;
+    long tweet2 = 2;
+    long tweet3 = 3;
+    long tweet4 = 4;
+    long tweet5 = 5;
+    long tweet6 = 6;
+    long tweet7 = 7;
+    long tweet8 = 8;
+
+    NodeMetadataLeftIndexedMultiSegmentBipartiteGraph nodeMetadataGraph =
+      new NodeMetadataLeftIndexedPowerLawMultiSegmentBipartiteGraph(
+        3,
+        10,
+        10,
+        10,
+        2.0,
+        100,
+        2,
+        new HigherBitsEdgeTypeMask(),
+        new NullStatsReceiver()
+      );
+    int[][] nodeMeta = new int[][]{};
+    nodeMetadataGraph.addEdge(user1, tweet1, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet1, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+
+    nodeMetadataGraph.addEdge(user1, tweet2, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet2, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet2, favoriteEdge, 0L, nodeMeta, nodeMeta);
+
+    nodeMetadataGraph.addEdge(user1, tweet3, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user2, tweet3, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+
+    nodeMetadataGraph.addEdge(user1, tweet4, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user2, tweet4, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+
+    nodeMetadataGraph.addEdge(user1, tweet5, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet5, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user2, tweet5, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user3, tweet5, favoriteEdge, 0L, nodeMeta, nodeMeta);
+
+    nodeMetadataGraph.addEdge(user2, tweet6, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user2, tweet6, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user2, tweet6, retweetEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user3, tweet6, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+
+    nodeMetadataGraph.addEdge(user1, tweet7, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user3, tweet7, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user3, tweet7, retweetEdge, 0L, nodeMeta, nodeMeta);
+
+    nodeMetadataGraph.addEdge(user4, tweet8, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet8, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user3, tweet8, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+
+    return nodeMetadataGraph;
+  }
+
+  /**
    * Build a small test NodeMetadataLeftIndexedMultiSegmentBipartiteGraph.
    *
    * @return a small test {@link NodeMetadataLeftIndexedMultiSegmentBipartiteGraph}

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountForTweetTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountForTweetTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Twitter. All rights reserved.
+ * Copyright 2018 Twitter. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,22 +57,21 @@ import it.unimi.dsi.fastutil.longs.LongSet;
 public class TopSecondDegreeByCountForTweetTest {
 
   @Test
-  public void testTopSecondDegreeByCountWithSmallGraph() throws Exception {
+  public void testTopSecondDegreeByCountWithSmallGraph() {
     NodeMetadataLeftIndexedMultiSegmentBipartiteGraph bipartiteGraph =
       BipartiteGraphTestHelper.buildSmallTestNodeMetadataLeftIndexedMultiSegmentBipartiteGraph();
     long queryNode = 1;
     Long2DoubleMap seedsMap = new Long2DoubleArrayMap(new long[]{2, 3}, new double[]{1.0, 0.5});
     LongSet toBeFiltered = new LongOpenHashSet(new long[]{2, 3, 4, 5});
-    Set<RecommendationType> recommendationTypes = new HashSet<RecommendationType>();
+    Set<RecommendationType> recommendationTypes = new HashSet<>();
     recommendationTypes.add(RecommendationType.HASHTAG);
     recommendationTypes.add(RecommendationType.URL);
     recommendationTypes.add(RecommendationType.TWEET);
-    Map<RecommendationType, Integer> maxNumResults = new HashMap<RecommendationType, Integer>();
+    Map<RecommendationType, Integer> maxNumResults = new HashMap<>();
     maxNumResults.put(RecommendationType.HASHTAG, 3);
     maxNumResults.put(RecommendationType.URL, 3);
     maxNumResults.put(RecommendationType.TWEET, 3);
-    Map<RecommendationType, Integer> minUserSocialProofSizes =
-      new HashMap<RecommendationType, Integer>();
+    Map<RecommendationType, Integer> minUserSocialProofSizes = new HashMap<>();
     minUserSocialProofSizes.put(RecommendationType.HASHTAG, 1);
     minUserSocialProofSizes.put(RecommendationType.URL, 1);
     minUserSocialProofSizes.put(RecommendationType.TWEET, 1);
@@ -142,17 +141,17 @@ public class TopSecondDegreeByCountForTweetTest {
   }
 
   @Test
-  public void testTopSecondDegreeByCountWithSocialProofTypeUnionsWithSmallGraph() throws Exception {
+  public void testTopSecondDegreeByCountWithSocialProofTypeUnionsWithSmallGraph() {
     NodeMetadataLeftIndexedMultiSegmentBipartiteGraph bipartiteGraph =
       BipartiteGraphTestHelper.buildSmallTestNodeMetadataLeftIndexedMultiSegmentBipartiteGraphWithEdgeTypes();
     long queryNode = 1;
     Long2DoubleMap seedsMap = new Long2DoubleArrayMap(new long[]{1, 2, 3}, new double[]{1.5, 1.0, 0.5});
     LongSet toBeFiltered = new LongOpenHashSet(new long[]{});
-    Set<RecommendationType> recommendationTypes = new HashSet<RecommendationType>();
+    Set<RecommendationType> recommendationTypes = new HashSet<>();
     recommendationTypes.add(RecommendationType.TWEET);
-    Map<RecommendationType, Integer> maxNumResults = new HashMap<RecommendationType, Integer>();
+    Map<RecommendationType, Integer> maxNumResults = new HashMap<>();
     maxNumResults.put(RecommendationType.TWEET, 3);
-    Map<RecommendationType, Integer> minUserSocialProofSizes = new HashMap<RecommendationType, Integer>();
+    Map<RecommendationType, Integer> minUserSocialProofSizes = new HashMap<>();
     minUserSocialProofSizes.put(RecommendationType.TWEET, 2);
 
     int maxUserSocialProofSize = 3;
@@ -204,7 +203,7 @@ public class TopSecondDegreeByCountForTweetTest {
     socialProof.get(1).put((byte) 0, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{2}), metadata1));
     socialProof.get(1).put((byte) 3, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{1}), metadata1));
 
-    final List<RecommendationInfo> expectedTopResults = new ArrayList<RecommendationInfo>();
+    final List<RecommendationInfo> expectedTopResults = new ArrayList<>();
     expectedTopResults.add(new TweetRecommendationInfo(3, 3.0, socialProof.get(0)));
     expectedTopResults.add(new TweetRecommendationInfo(5, 2.5, socialProof.get(1)));
 
@@ -221,7 +220,102 @@ public class TopSecondDegreeByCountForTweetTest {
   }
 
   @Test
-  public void testTopSecondDegreeByCountWithRandomGraph() throws Exception {
+  public void testTopSecondDegreeByCountWithSmallGraphWithEdgeRemoval() {
+    byte favoriteType = 1;
+    byte unfavoriteType = 8;
+    byte retweetType = 2;
+
+    NodeMetadataLeftIndexedMultiSegmentBipartiteGraph bipartiteGraph =
+      BipartiteGraphTestHelper.buildTestNodeMetadataLeftIndexedMultiSegmentBipartiteGraphWithUnfavorite(
+          favoriteType, unfavoriteType, retweetType);
+
+    long queryNode = 1;
+    Long2DoubleMap seedsMap = new Long2DoubleArrayMap(new long[]{1, 2, 3, 4}, new double[]{1, 3, 5, 7});
+    LongSet toBeFiltered = new LongOpenHashSet(new long[]{});
+    Set<RecommendationType> recommendationTypes = new HashSet<>();
+    recommendationTypes.add(RecommendationType.TWEET);
+
+    Map<RecommendationType, Integer> maxNumResults = new HashMap<>();
+    maxNumResults.put(RecommendationType.TWEET, 10);
+    Map<RecommendationType, Integer> minUserSocialProofSizes = new HashMap<>();
+    minUserSocialProofSizes.put(RecommendationType.TWEET, 1);
+
+    int maxUserSocialProofSize = 10;
+    int maxTweetSocialProofSize = 10;
+
+    byte[] validSocialProofs = new byte[]{favoriteType, retweetType};
+    int maxSocialProofTypeSize = 10;
+
+    int expectedNodesToHit = 100;
+    Random random = new Random(918324701982347L);
+    long maxRightNodeAgeInMillis = Long.MAX_VALUE;
+    long maxEdgeAgeInMillis = Long.MAX_VALUE;
+    ResultFilterChain resultFilterChain = new ResultFilterChain(Lists.newArrayList());
+    Set<byte[]> socialProofTypeUnions = new HashSet<>();
+
+    TopSecondDegreeByCountRequestForTweet request = new TopSecondDegreeByCountRequestForTweet(
+        queryNode,
+        seedsMap,
+        toBeFiltered,
+        recommendationTypes,
+        maxNumResults,
+        maxSocialProofTypeSize,
+        maxUserSocialProofSize,
+        maxTweetSocialProofSize,
+        minUserSocialProofSizes,
+        validSocialProofs,
+        maxRightNodeAgeInMillis,
+        maxEdgeAgeInMillis,
+        resultFilterChain,
+        socialProofTypeUnions
+    );
+
+    TopSecondDegreeByCountResponse response = new TopSecondDegreeByCountForTweet(
+        bipartiteGraph,
+        expectedNodesToHit,
+        new NullStatsReceiver()
+    ).computeRecommendations(request, random);
+
+    LongList metadata1 = new LongArrayList(new long[]{0});
+    LongList metadata2 = new LongArrayList(new long[]{0, 0});
+
+    HashMap<Byte, ConnectingUsersWithMetadata> tweet3SocialProof = new HashMap<>();
+      tweet3SocialProof.put(
+        favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{1}), metadata1));
+
+    HashMap<Byte, ConnectingUsersWithMetadata> tweet5SocialProof = new HashMap<>();
+      tweet5SocialProof.put(
+        favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{3, 2}), metadata2));
+
+    HashMap<Byte, ConnectingUsersWithMetadata> tweet6SocialProof = new HashMap<>();
+      tweet6SocialProof.put(
+        retweetType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{2}), metadata1));
+
+    HashMap<Byte, ConnectingUsersWithMetadata> tweet7SocialProof = new HashMap<>();
+    tweet7SocialProof.put(
+        favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{1}), metadata1));
+    tweet7SocialProof.put(
+        retweetType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{3}), metadata1));
+
+    HashMap<Byte, ConnectingUsersWithMetadata> tweet8SocialProof = new HashMap<>();
+    tweet8SocialProof.put(
+        favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{4}), metadata1));
+
+    List<RecommendationInfo> topSecondDegreeByCountResults =
+      Lists.newArrayList(response.getRankedRecommendations());
+    List<RecommendationInfo> expectedResults = new ArrayList<>();
+
+    expectedResults.add(new TweetRecommendationInfo(5, 8, tweet5SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(8, 7, tweet8SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(7, 6, tweet7SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(6, 3, tweet6SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(3, 1, tweet3SocialProof));
+
+    assertEquals(expectedResults, topSecondDegreeByCountResults);
+  }
+
+  @Test
+  public void testTopSecondDegreeByCountWithRandomGraph() {
     long randomSeed = 918324701982347L;
     Random random = new Random(randomSeed);
 

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountForTweetTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountForTweetTest.java
@@ -230,7 +230,7 @@ public class TopSecondDegreeByCountForTweetTest {
           favoriteType, unfavoriteType, retweetType);
 
     long queryNode = 1;
-    Long2DoubleMap seedsMap = new Long2DoubleArrayMap(new long[]{1, 2, 3, 4}, new double[]{1, 3, 5, 7});
+    Long2DoubleMap seedsMap = new Long2DoubleArrayMap(new long[]{1, 2, 3, 4, 5}, new double[]{1, 3, 5, 7, 9});
     LongSet toBeFiltered = new LongOpenHashSet(new long[]{});
     Set<RecommendationType> recommendationTypes = new HashSet<>();
     recommendationTypes.add(RecommendationType.TWEET);
@@ -280,31 +280,36 @@ public class TopSecondDegreeByCountForTweetTest {
     LongList metadata2 = new LongArrayList(new long[]{0, 0});
 
     HashMap<Byte, ConnectingUsersWithMetadata> tweet3SocialProof = new HashMap<>();
-      tweet3SocialProof.put(
-        favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{1}), metadata1));
+    tweet3SocialProof.put(
+      favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{1}), metadata1));
 
     HashMap<Byte, ConnectingUsersWithMetadata> tweet5SocialProof = new HashMap<>();
-      tweet5SocialProof.put(
-        favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{3, 2}), metadata2));
+    tweet5SocialProof.put(
+      favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{3, 2}), metadata2));
 
     HashMap<Byte, ConnectingUsersWithMetadata> tweet6SocialProof = new HashMap<>();
-      tweet6SocialProof.put(
-        retweetType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{2}), metadata1));
+    tweet6SocialProof.put(
+      retweetType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{2}), metadata1));
 
     HashMap<Byte, ConnectingUsersWithMetadata> tweet7SocialProof = new HashMap<>();
     tweet7SocialProof.put(
-        favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{1}), metadata1));
+      favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{1}), metadata1));
     tweet7SocialProof.put(
-        retweetType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{3}), metadata1));
+      retweetType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{3}), metadata1));
 
     HashMap<Byte, ConnectingUsersWithMetadata> tweet8SocialProof = new HashMap<>();
     tweet8SocialProof.put(
-        favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{4}), metadata1));
+      favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{4}), metadata1));
+
+    HashMap<Byte, ConnectingUsersWithMetadata> tweet9SocialProof = new HashMap<>();
+    tweet9SocialProof.put(
+      favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{3, 4}), metadata2));
 
     List<RecommendationInfo> topSecondDegreeByCountResults =
       Lists.newArrayList(response.getRankedRecommendations());
     List<RecommendationInfo> expectedResults = new ArrayList<>();
 
+    expectedResults.add(new TweetRecommendationInfo(9, 12, tweet5SocialProof));
     expectedResults.add(new TweetRecommendationInfo(5, 8, tweet5SocialProof));
     expectedResults.add(new TweetRecommendationInfo(8, 7, tweet8SocialProof));
     expectedResults.add(new TweetRecommendationInfo(7, 6, tweet7SocialProof));

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountForTweetTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountForTweetTest.java
@@ -219,6 +219,10 @@ public class TopSecondDegreeByCountForTweetTest {
     assertEquals(expectedTopResults, topSecondDegreeByCountResults);
   }
 
+  /**
+   * Test a small graph that contain favorite and unfavorite edges to make sure they are
+   * removed correctly.
+   */
   @Test
   public void testTopSecondDegreeByCountWithSmallGraphWithEdgeRemoval() {
     byte favoriteType = 1;
@@ -231,6 +235,8 @@ public class TopSecondDegreeByCountForTweetTest {
 
     long queryNode = 1;
     Long2DoubleMap seedsMap = new Long2DoubleArrayMap(new long[]{1, 2, 3, 4, 5}, new double[]{1, 3, 5, 7, 9});
+    byte[] validSocialProofs = new byte[]{favoriteType, retweetType};
+
     LongSet toBeFiltered = new LongOpenHashSet(new long[]{});
     Set<RecommendationType> recommendationTypes = new HashSet<>();
     recommendationTypes.add(RecommendationType.TWEET);
@@ -242,10 +248,7 @@ public class TopSecondDegreeByCountForTweetTest {
 
     int maxUserSocialProofSize = 10;
     int maxTweetSocialProofSize = 10;
-
-    byte[] validSocialProofs = new byte[]{favoriteType, retweetType};
     int maxSocialProofTypeSize = 10;
-
     int expectedNodesToHit = 100;
     Random random = new Random(918324701982347L);
     long maxRightNodeAgeInMillis = Long.MAX_VALUE;
@@ -254,26 +257,26 @@ public class TopSecondDegreeByCountForTweetTest {
     Set<byte[]> socialProofTypeUnions = new HashSet<>();
 
     TopSecondDegreeByCountRequestForTweet request = new TopSecondDegreeByCountRequestForTweet(
-        queryNode,
-        seedsMap,
-        toBeFiltered,
-        recommendationTypes,
-        maxNumResults,
-        maxSocialProofTypeSize,
-        maxUserSocialProofSize,
-        maxTweetSocialProofSize,
-        minUserSocialProofSizes,
-        validSocialProofs,
-        maxRightNodeAgeInMillis,
-        maxEdgeAgeInMillis,
-        resultFilterChain,
-        socialProofTypeUnions
+      queryNode,
+      seedsMap,
+      toBeFiltered,
+      recommendationTypes,
+      maxNumResults,
+      maxSocialProofTypeSize,
+      maxUserSocialProofSize,
+      maxTweetSocialProofSize,
+      minUserSocialProofSizes,
+      validSocialProofs,
+      maxRightNodeAgeInMillis,
+      maxEdgeAgeInMillis,
+      resultFilterChain,
+      socialProofTypeUnions
     );
 
     TopSecondDegreeByCountResponse response = new TopSecondDegreeByCountForTweet(
-        bipartiteGraph,
-        expectedNodesToHit,
-        new NullStatsReceiver()
+      bipartiteGraph,
+      expectedNodesToHit,
+      new NullStatsReceiver()
     ).computeRecommendations(request, random);
 
     LongList metadata1 = new LongArrayList(new long[]{0});
@@ -303,13 +306,13 @@ public class TopSecondDegreeByCountForTweetTest {
 
     HashMap<Byte, ConnectingUsersWithMetadata> tweet9SocialProof = new HashMap<>();
     tweet9SocialProof.put(
-      favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{3, 4}), metadata2));
+      favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{4, 3}), metadata2));
 
     List<RecommendationInfo> topSecondDegreeByCountResults =
       Lists.newArrayList(response.getRankedRecommendations());
     List<RecommendationInfo> expectedResults = new ArrayList<>();
 
-    expectedResults.add(new TweetRecommendationInfo(9, 12, tweet5SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(9, 12, tweet9SocialProof));
     expectedResults.add(new TweetRecommendationInfo(5, 8, tweet5SocialProof));
     expectedResults.add(new TweetRecommendationInfo(8, 7, tweet8SocialProof));
     expectedResults.add(new TweetRecommendationInfo(7, 6, tweet7SocialProof));

--- a/graphjet-demo/pom.xml
+++ b/graphjet-demo/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.1.11-SNAPSHOT</version>
+    <version>1.1.12-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-demo</artifactId>
-  <version>1.1.11-SNAPSHOT</version>
+  <version>1.1.12-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Demo</name>
   <description>GraphJet is a real-time graph processing library: demo of core graph library</description>
@@ -26,12 +26,12 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.1.11-SNAPSHOT</version>
+      <version>1.1.12-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-adapters</artifactId>
-      <version>1.1.11-SNAPSHOT</version>
+      <version>1.1.12-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -101,20 +101,6 @@
     </plugins>
   </build>
 
-
-<distributionManagement>
-    <repository>
-        <id>artifactory-snapshot</id>
-        <name>Apache Release Distribution Repository</name>
-        <url>https://artifactory.twitter.biz/libs-releases-local</url>
-    </repository>
-    <snapshotRepository>
-        <id>artifactory-snapshot</id>
-        <name>twitter</name>
-        <url>https://artifactory.twitter.biz/libs-releases-local</url>
-    </snapshotRepository>
-</distributionManagement>
-
   <modules>
     <module>graphjet-core</module>
     <module>graphjet-adapters</module>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet</artifactId>
-  <version>1.1.11-SNAPSHOT</version>
+  <version>1.1.10</version>
   <packaging>pom</packaging>
 
   <name>graphjet</name>
@@ -100,6 +100,20 @@
       </plugin>
     </plugins>
   </build>
+
+
+<distributionManagement>
+    <repository>
+        <id>artifactory-snapshot</id>
+        <name>Apache Release Distribution Repository</name>
+        <url>https://artifactory.twitter.biz/libs-releases-local</url>
+    </repository>
+    <snapshotRepository>
+        <id>artifactory-snapshot</id>
+        <name>twitter</name>
+        <url>https://artifactory.twitter.biz/libs-releases-local</url>
+    </snapshotRepository>
+</distributionManagement>
 
   <modules>
     <module>graphjet-core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet</artifactId>
-  <version>1.1.10</version>
+  <version>1.1.12-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>graphjet</name>


### PR DESCRIPTION
This request adds the functionality to "remove" tweet favorite edges that are later on unfavorited. For example, userA "favs" and later on "unfavs" Tweet1. This has been a much requested feature, but inherently, GraphJet's internal graph storage is read-only, making it impossible to undo a favorite edge. 

One alternative to achieving this feature, at least from the client's point of view, is that we introduce a counter edge, "unfavorite" edge, and index that edge into the graph. 
During graph traversal, for each tweet, we collect every engagement edge, including fav and unfavs, into a NodeInfo object. Before ranking, however, we re-check the NodeInfo and look for possible fav-unfav edge pairs. We remove these pairs from NodeInfo in-place should they exist. This way the unfavorited edge will be absent during ranking, and thus not returned to the client.