### PR TITLE
Add fix to cover an edge case in tweet unfavorite path

### DIFF
--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.1.12-SNAPSHOT</version>
+    <version>1.1.13-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-adapters</artifactId>
-  <version>1.1.12-SNAPSHOT</version>
+  <version>1.1.13-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Adapters</name>
   <description>GraphJet is a real-time graph processing library: adapters for other graph systems</description>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.1.12-SNAPSHOT</version>
+      <version>1.1.13-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>

--- a/graphjet-core/pom.xml
+++ b/graphjet-core/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.1.12-SNAPSHOT</version>
+    <version>1.1.13-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-core</artifactId>
-  <version>1.1.12-SNAPSHOT</version>
+  <version>1.1.13-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Core</name>
   <description>GraphJet is a real-time graph processing library: core graph library and recommendation algorithms</description>

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/RecommendationRequest.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/RecommendationRequest.java
@@ -26,7 +26,11 @@ public abstract class RecommendationRequest {
   private final long queryNode;
   private final LongSet toBeFiltered;
   private final byte[] socialProofTypes;
-  public static final int AUTHOR_SOCIAL_PROOF_TYPE = 4;
+  public static final byte FAVORITE_SOCIAL_PROOF_TYPE = 1;
+  public static final byte RETWEET_SOCIAL_PROOF_TYPE = 2;
+  public static final byte AUTHOR_SOCIAL_PROOF_TYPE = 4;
+  public static final byte UNFAVORITE_SOCIAL_PROOF_TYPE = 8;
+
   public static final int DEFAULT_MIN_USER_SOCIAL_PROOF_SIZE = 1;
   public static final int DEFAULT_RECOMMENDATION_RESULTS = 100;
   public static final int MAX_EDGES_PER_NODE = 500;

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountForTweet.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountForTweet.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package com.twitter.graphjet.algorithms.counting.tweet;
 
 import java.util.ArrayList;

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -16,7 +16,6 @@
 
 package com.twitter.graphjet.algorithms.counting.tweet;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -26,7 +25,6 @@ import com.google.common.collect.Lists;
 
 import com.twitter.graphjet.algorithms.NodeInfo;
 import com.twitter.graphjet.algorithms.RecommendationInfo;
-import com.twitter.graphjet.algorithms.RecommendationRequest;
 import com.twitter.graphjet.algorithms.RecommendationType;
 import com.twitter.graphjet.algorithms.TweetIDMask;
 import com.twitter.graphjet.algorithms.counting.GeneratorHelper;
@@ -35,16 +33,18 @@ import com.twitter.graphjet.hashing.SmallArrayBasedLongToDoubleMap;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 
+import static com.twitter.graphjet.algorithms.RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE;
+import static com.twitter.graphjet.algorithms.RecommendationRequest.FAVORITE_SOCIAL_PROOF_TYPE;
+import static com.twitter.graphjet.algorithms.RecommendationRequest.UNFAVORITE_SOCIAL_PROOF_TYPE;
+
 public final class TopSecondDegreeByCountTweetRecsGenerator {
   private static final TweetIDMask TWEET_ID_MASK = new TweetIDMask();
-  private static final byte FavoriteSocialProofType = 1;
-  private static final byte UnfavoriteSocialProofType = 8;
 
   private TopSecondDegreeByCountTweetRecsGenerator() {
   }
 
   private static boolean isUnfavoriteTypeSupported(NodeInfo nodeInfo) {
-    return UnfavoriteSocialProofType < nodeInfo.getSocialProofs().length;
+    return UNFAVORITE_SOCIAL_PROOF_TYPE < nodeInfo.getSocialProofs().length;
   }
 
   /**
@@ -60,35 +60,40 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
     }
 
     SmallArrayBasedLongToDoubleMap[] socialProofs = nodeInfo.getSocialProofs();
-    SmallArrayBasedLongToDoubleMap unfavSocialProofs = socialProofs[UnfavoriteSocialProofType];
-    SmallArrayBasedLongToDoubleMap favSocialProofs = socialProofs[FavoriteSocialProofType];
+    SmallArrayBasedLongToDoubleMap unfavSocialProofs = socialProofs[UNFAVORITE_SOCIAL_PROOF_TYPE];
+    SmallArrayBasedLongToDoubleMap favSocialProofs = socialProofs[FAVORITE_SOCIAL_PROOF_TYPE];
 
-    if (unfavSocialProofs == null || favSocialProofs == null) {
+    if (unfavSocialProofs == null) {
       return false;
     }
 
-    SmallArrayBasedLongToDoubleMap newFavSocialProofs = new SmallArrayBasedLongToDoubleMap();
-    double weightToRemove = 0;
-
-    for (int i = 0; i < favSocialProofs.size(); i++) {
-      long favUser = favSocialProofs.keys()[i];
-      double favWeight = favSocialProofs.values()[i];
-
-      if (unfavSocialProofs.contains(favUser)) {
-        weightToRemove += favSocialProofs.values()[i];
-      } else {
-        newFavSocialProofs.put(favUser, favWeight, favSocialProofs.metadata()[i]);
-      }
-    }
-
+    // Remove unfavorite social proofs and the corresponding weights
+    double unfavWeightToRemove = 0;
     for (int i = 0; i < unfavSocialProofs.size(); i++) {
-      weightToRemove += unfavSocialProofs.values()[i];
+      unfavWeightToRemove += unfavSocialProofs.values()[i];
+    }
+    nodeInfo.setWeight(nodeInfo.getWeight() - unfavWeightToRemove);
+    socialProofs[UNFAVORITE_SOCIAL_PROOF_TYPE] = null;
+
+    // Remove favorite social proofs that were unfavorited and the corresponding weights
+    if (favSocialProofs != null) {
+      int favWeightToRemove = 0;
+      SmallArrayBasedLongToDoubleMap newFavSocialProofs = new SmallArrayBasedLongToDoubleMap();
+      for (int i = 0; i < favSocialProofs.size(); i++) {
+        long favUser = favSocialProofs.keys()[i];
+        double favWeight = favSocialProofs.values()[i];
+
+        if (unfavSocialProofs.contains(favUser)) {
+          favWeightToRemove += favWeight;
+        } else {
+          newFavSocialProofs.put(favUser, favWeight, favSocialProofs.metadata()[i]);
+        }
+      }
+      // Add the filtered Favorite social proofs
+      nodeInfo.setWeight(nodeInfo.getWeight() - favWeightToRemove);
+      socialProofs[FAVORITE_SOCIAL_PROOF_TYPE] = (newFavSocialProofs.size() != 0) ? newFavSocialProofs : null;
     }
 
-    // Add the filtered Favorite social proofs, and remove the Unfavorite social proofs from nodeInfo
-    nodeInfo.setWeight(nodeInfo.getWeight() - weightToRemove);
-    socialProofs[FavoriteSocialProofType] = (newFavSocialProofs.size() != 0) ? newFavSocialProofs : null;
-    socialProofs[UnfavoriteSocialProofType] = null;
     return true;
   }
 
@@ -119,7 +124,7 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
     int minUserSocialProofSize = GeneratorHelper.getMinUserSocialProofSize(request, RecommendationType.TWEET);
     byte[] validSocialProofs = request.getSocialProofTypes();
 
-    PriorityQueue<NodeInfo> topResults = new PriorityQueue<NodeInfo>(maxNumResults);
+    PriorityQueue<NodeInfo> topResults = new PriorityQueue<>(maxNumResults);
 
     // handling specific rules of tweet recommendations
     for (NodeInfo nodeInfo : nodeInfoList) {
@@ -142,11 +147,11 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
     List<RecommendationInfo> outputResults = Lists.newArrayListWithCapacity(topResults.size());
     while (!topResults.isEmpty()) {
       NodeInfo nodeInfo = topResults.poll();
-      outputResults.add(
-        new TweetRecommendationInfo(
-          TWEET_ID_MASK.restore(nodeInfo.getNodeId()),
-          nodeInfo.getWeight(),
-          GeneratorHelper.pickTopSocialProofs(nodeInfo.getSocialProofs())));
+      TweetRecommendationInfo info = new TweetRecommendationInfo(
+        TWEET_ID_MASK.restore(nodeInfo.getNodeId()),
+        nodeInfo.getWeight(),
+        GeneratorHelper.pickTopSocialProofs(nodeInfo.getSocialProofs()));
+      outputResults.add(info);
     }
     Collections.reverse(outputResults);
 
@@ -215,7 +220,7 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
         int minUserSocialProofThreshold = minUserSocialProofSize;
         if (authorId != -1 &&
           // Skip tweet author social proof because its size can be only one
-            validSocialProofType != RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE &&
+          validSocialProofType != AUTHOR_SOCIAL_PROOF_TYPE &&
           socialProofs[validSocialProofType].contains(authorId)) {
           minUserSocialProofThreshold += 1;
         }
@@ -229,7 +234,7 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
 
   // Return the authorId of the Tweet, if the author is in the leftSeedNodesWithWeight; otherwise, return -1.
   private static long getAuthorId(SmallArrayBasedLongToDoubleMap[] socialProofs) {
-    int socialProofTypeTweet = RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE;
+    int socialProofTypeTweet = AUTHOR_SOCIAL_PROOF_TYPE;
     long authorId = -1;
     if (socialProofs[socialProofTypeTweet] != null) {
       // There cannot be more than one key associated with the Tweet socialProofType

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -147,11 +147,11 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
     List<RecommendationInfo> outputResults = Lists.newArrayListWithCapacity(topResults.size());
     while (!topResults.isEmpty()) {
       NodeInfo nodeInfo = topResults.poll();
-      TweetRecommendationInfo info = new TweetRecommendationInfo(
-        TWEET_ID_MASK.restore(nodeInfo.getNodeId()),
-        nodeInfo.getWeight(),
-        GeneratorHelper.pickTopSocialProofs(nodeInfo.getSocialProofs()));
-      outputResults.add(info);
+      outputResults.add(
+        new TweetRecommendationInfo(
+          TWEET_ID_MASK.restore(nodeInfo.getNodeId()),
+          nodeInfo.getWeight(),
+          GeneratorHelper.pickTopSocialProofs(nodeInfo.getSocialProofs())));
     }
     Collections.reverse(outputResults);
 

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweet/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -67,7 +67,8 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
       return false;
     }
 
-    // Remove unfavorite social proofs and the corresponding weights
+    // Always remove unfavorite social proofs, as they are only meant for internal processing and
+    // not to be returned to the caller.
     double unfavWeightToRemove = 0;
     for (int i = 0; i < unfavSocialProofs.size(); i++) {
       unfavWeightToRemove += unfavSocialProofs.values()[i];

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -71,7 +71,8 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
       return false;
     }
 
-    // Remove unfavorite social proofs and the corresponding weights
+    // Always remove unfavorite social proofs, as they are only meant for internal processing and
+    // not to be returned to the caller.
     double unfavWeightToRemove = 0;
     for (int i = 0; i < unfavSocialProofs.size(); i++) {
       unfavWeightToRemove += unfavSocialProofs.values()[i];

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -35,6 +35,9 @@ import com.twitter.graphjet.hashing.SmallArrayBasedLongToDoubleMap;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 
+import static com.twitter.graphjet.algorithms.RecommendationRequest.FAVORITE_SOCIAL_PROOF_TYPE;
+import static com.twitter.graphjet.algorithms.RecommendationRequest.UNFAVORITE_SOCIAL_PROOF_TYPE;
+
 public final class TopSecondDegreeByCountTweetRecsGenerator {
   private static final TweetIDMask TWEET_ID_MASK = new TweetIDMask();
   private static final byte FavoriteSocialProofType = 1;
@@ -46,6 +49,7 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
   private static boolean isUnfavoriteTypeSupported(NodeInfo nodeInfo) {
     return UnfavoriteSocialProofType < nodeInfo.getSocialProofs().length;
   }
+
 
   /**
    * Given a nodeInfo containing the collection of all social proofs on a tweet, remove the
@@ -60,37 +64,43 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
     }
 
     SmallArrayBasedLongToDoubleMap[] socialProofs = nodeInfo.getSocialProofs();
-    SmallArrayBasedLongToDoubleMap unfavSocialProofs = socialProofs[UnfavoriteSocialProofType];
-    SmallArrayBasedLongToDoubleMap favSocialProofs = socialProofs[FavoriteSocialProofType];
+    SmallArrayBasedLongToDoubleMap unfavSocialProofs = socialProofs[UNFAVORITE_SOCIAL_PROOF_TYPE];
+    SmallArrayBasedLongToDoubleMap favSocialProofs = socialProofs[FAVORITE_SOCIAL_PROOF_TYPE];
 
-    if (unfavSocialProofs == null || favSocialProofs == null) {
+    if (unfavSocialProofs == null) {
       return false;
     }
 
-    SmallArrayBasedLongToDoubleMap newFavSocialProofs = new SmallArrayBasedLongToDoubleMap();
-    double weightToRemove = 0;
-
-    for (int i = 0; i < favSocialProofs.size(); i++) {
-      long favUser = favSocialProofs.keys()[i];
-      double favWeight = favSocialProofs.values()[i];
-
-      if (unfavSocialProofs.contains(favUser)) {
-        weightToRemove += favSocialProofs.values()[i];
-      } else {
-        newFavSocialProofs.put(favUser, favWeight, favSocialProofs.metadata()[i]);
-      }
-    }
-
+    // Remove unfavorite social proofs and the corresponding weights
+    double unfavWeightToRemove = 0;
     for (int i = 0; i < unfavSocialProofs.size(); i++) {
-      weightToRemove += unfavSocialProofs.values()[i];
+      unfavWeightToRemove += unfavSocialProofs.values()[i];
+    }
+    nodeInfo.setWeight(nodeInfo.getWeight() - unfavWeightToRemove);
+    socialProofs[UNFAVORITE_SOCIAL_PROOF_TYPE] = null;
+
+    // Remove favorite social proofs that were unfavorited and the corresponding weights
+    if (favSocialProofs != null) {
+      int favWeightToRemove = 0;
+      SmallArrayBasedLongToDoubleMap newFavSocialProofs = new SmallArrayBasedLongToDoubleMap();
+      for (int i = 0; i < favSocialProofs.size(); i++) {
+        long favUser = favSocialProofs.keys()[i];
+        double favWeight = favSocialProofs.values()[i];
+
+        if (unfavSocialProofs.contains(favUser)) {
+          favWeightToRemove += favWeight;
+        } else {
+          newFavSocialProofs.put(favUser, favWeight, favSocialProofs.metadata()[i]);
+        }
+      }
+      // Add the filtered Favorite social proofs
+      nodeInfo.setWeight(nodeInfo.getWeight() - favWeightToRemove);
+      socialProofs[FAVORITE_SOCIAL_PROOF_TYPE] = (newFavSocialProofs.size() != 0) ? newFavSocialProofs : null;
     }
 
-    // Add the filtered Favorite social proofs, and remove the Unfavorite social proofs from nodeInfo
-    nodeInfo.setWeight(nodeInfo.getWeight() - weightToRemove);
-    socialProofs[FavoriteSocialProofType] = (newFavSocialProofs.size() != 0) ? newFavSocialProofs : null;
-    socialProofs[UnfavoriteSocialProofType] = null;
     return true;
   }
+
 
   /**
    * Given a nodeInfo, check all social proofs stored and determine if it still has

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/BipartiteGraphTestHelper.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/BipartiteGraphTestHelper.java
@@ -207,14 +207,6 @@ public final class BipartiteGraphTestHelper {
   /**
    * Builds a small test graph with special edge types Favorite (1) and Unfavorite (8). This test
    * graph is built specifically for the counting algorithms on tweets.
-   * The resultant graph after removing unfavorited edges consists of the following engagements:
-   * tweet1, tweet2, tweet3: no engagement
-   * tweet4: user1 Favorite
-   * tweet5: user2, user3 Favorite
-   * tweet6: user2 Retweet
-   * tweet7: user1 Favorite, user3 Retweet
-   * tweet8: user4 Favorite
-   * tweet9: user3, user4 Favorite
    *
    * @return a small test {@link NodeMetadataLeftIndexedMultiSegmentBipartiteGraph}
    */
@@ -227,6 +219,14 @@ public final class BipartiteGraphTestHelper {
     long user3 = 3;
     long user4 = 4;
     long user5 = 5;
+    long user7 = 7;
+    long user8 = 8;
+    long user9 = 9;
+    long user10 = 10;
+    long user11 = 11;
+    long user12 = 12;
+    long user13 = 13;
+    long user14 = 14;
 
     long tweet1 = 1;
     long tweet2 = 2;
@@ -237,11 +237,15 @@ public final class BipartiteGraphTestHelper {
     long tweet7 = 7;
     long tweet8 = 8;
     long tweet9 = 9;
+    long tweet10 = 10;
+    long tweet11 = 11;
+    long tweet12 = 12;
+    long tweet13 = 13;
 
     NodeMetadataLeftIndexedMultiSegmentBipartiteGraph nodeMetadataGraph =
       new NodeMetadataLeftIndexedPowerLawMultiSegmentBipartiteGraph(
         10,
-        5,
+        6,
         10,
         10,
         2.0,
@@ -251,45 +255,66 @@ public final class BipartiteGraphTestHelper {
         new NullStatsReceiver()
       );
     int[][] nodeMeta = new int[][]{};
+
+    // Only Favorite
     nodeMetadataGraph.addEdge(user1, tweet1, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user1, tweet1, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
 
-    nodeMetadataGraph.addEdge(user1, tweet2, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user1, tweet2, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user1, tweet2, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    // Only Retweet
+    nodeMetadataGraph.addEdge(user2, tweet2, retweetEdge, 0L, nodeMeta, nodeMeta);
 
-    nodeMetadataGraph.addEdge(user1, tweet3, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    // Only Unfavorite
+    // invalid node
+    nodeMetadataGraph.addEdge(user1, tweet3, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
     nodeMetadataGraph.addEdge(user2, tweet3, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
 
+    // Favorite & Unfavorite
+    // invalid node
+    nodeMetadataGraph.addEdge(user1, tweet4, favoriteEdge, 0L, nodeMeta, nodeMeta);
     nodeMetadataGraph.addEdge(user1, tweet4, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user2, tweet4, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
 
-    nodeMetadataGraph.addEdge(user1, tweet5, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user1, tweet5, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user2, tweet5, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user3, tweet5, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user5, tweet5, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user2, tweet5, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
 
-    nodeMetadataGraph.addEdge(user2, tweet6, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user2, tweet6, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user2, tweet6, retweetEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user3, tweet6, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    // invalid node
+    nodeMetadataGraph.addEdge(user1, tweet6, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet6, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet6, favoriteEdge, 0L, nodeMeta, nodeMeta);
 
-    nodeMetadataGraph.addEdge(user1, tweet7, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user7, tweet7, favoriteEdge, 0L, nodeMeta, nodeMeta);
     nodeMetadataGraph.addEdge(user3, tweet7, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user3, tweet7, retweetEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user4, tweet7, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
 
-    nodeMetadataGraph.addEdge(user4, tweet8, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet8, favoriteEdge, 0L, nodeMeta, nodeMeta);
     nodeMetadataGraph.addEdge(user1, tweet8, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user3, tweet8, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user8, tweet8, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user9, tweet8, favoriteEdge, 0L, nodeMeta, nodeMeta);
 
     nodeMetadataGraph.addEdge(user1, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
     nodeMetadataGraph.addEdge(user2, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user3, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user4, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user9, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user10, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
     nodeMetadataGraph.addEdge(user5, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
     nodeMetadataGraph.addEdge(user1, tweet9, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
     nodeMetadataGraph.addEdge(user2, tweet9, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
     nodeMetadataGraph.addEdge(user5, tweet9, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+
+    // Favorite & Retweet
+    nodeMetadataGraph.addEdge(user10, tweet10, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user11, tweet10, retweetEdge, 0L, nodeMeta, nodeMeta);
+
+    // Unfavorite & Retweet
+    nodeMetadataGraph.addEdge(user2, tweet11, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user11, tweet11, retweetEdge, 0L, nodeMeta, nodeMeta);
+
+    // Favorite, Unfavorite, and Retweet
+    nodeMetadataGraph.addEdge(user12, tweet12, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user12, tweet12, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user12, tweet12, retweetEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user3, tweet12, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+
+    nodeMetadataGraph.addEdge(user13, tweet13, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user14, tweet13, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user14, tweet13, retweetEdge, 0L, nodeMeta, nodeMeta);
 
     return nodeMetadataGraph;
   }

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountForTweetTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/counting/TopSecondDegreeByCountForTweetTest.java
@@ -45,6 +45,10 @@ import com.twitter.graphjet.algorithms.counting.tweet.TweetRecommendationInfo;
 import com.twitter.graphjet.bipartite.NodeMetadataLeftIndexedMultiSegmentBipartiteGraph;
 import com.twitter.graphjet.stats.NullStatsReceiver;
 
+import static com.twitter.graphjet.algorithms.RecommendationRequest.FAVORITE_SOCIAL_PROOF_TYPE;
+import static com.twitter.graphjet.algorithms.RecommendationRequest.RETWEET_SOCIAL_PROOF_TYPE;
+import static com.twitter.graphjet.algorithms.RecommendationRequest.UNFAVORITE_SOCIAL_PROOF_TYPE;
+
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import it.unimi.dsi.fastutil.doubles.DoubleList;
 import it.unimi.dsi.fastutil.longs.Long2DoubleArrayMap;
@@ -225,17 +229,15 @@ public class TopSecondDegreeByCountForTweetTest {
    */
   @Test
   public void testTopSecondDegreeByCountWithSmallGraphWithEdgeRemoval() {
-    byte favoriteType = 1;
-    byte unfavoriteType = 8;
-    byte retweetType = 2;
-
     NodeMetadataLeftIndexedMultiSegmentBipartiteGraph bipartiteGraph =
       BipartiteGraphTestHelper.buildTestNodeMetadataLeftIndexedMultiSegmentBipartiteGraphWithUnfavorite(
-          favoriteType, unfavoriteType, retweetType);
+        FAVORITE_SOCIAL_PROOF_TYPE, UNFAVORITE_SOCIAL_PROOF_TYPE, RETWEET_SOCIAL_PROOF_TYPE);
 
     long queryNode = 1;
-    Long2DoubleMap seedsMap = new Long2DoubleArrayMap(new long[]{1, 2, 3, 4, 5}, new double[]{1, 3, 5, 7, 9});
-    byte[] validSocialProofs = new byte[]{favoriteType, retweetType};
+    Long2DoubleMap seedsMap = new Long2DoubleArrayMap(
+      new long[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14},
+      new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14});
+    byte[] validSocialProofs = new byte[]{FAVORITE_SOCIAL_PROOF_TYPE, RETWEET_SOCIAL_PROOF_TYPE};
 
     LongSet toBeFiltered = new LongOpenHashSet(new long[]{});
     Set<RecommendationType> recommendationTypes = new HashSet<>();
@@ -282,42 +284,64 @@ public class TopSecondDegreeByCountForTweetTest {
     LongList metadata1 = new LongArrayList(new long[]{0});
     LongList metadata2 = new LongArrayList(new long[]{0, 0});
 
-    HashMap<Byte, ConnectingUsersWithMetadata> tweet3SocialProof = new HashMap<>();
-    tweet3SocialProof.put(
-      favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{1}), metadata1));
+    HashMap<Byte, ConnectingUsersWithMetadata> tweet1SocialProof = new HashMap<>();
+    tweet1SocialProof.put(
+        FAVORITE_SOCIAL_PROOF_TYPE, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{1}), metadata1));
+
+    HashMap<Byte, ConnectingUsersWithMetadata> tweet2SocialProof = new HashMap<>();
+    tweet2SocialProof.put(
+        RETWEET_SOCIAL_PROOF_TYPE, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{2}), metadata1));
 
     HashMap<Byte, ConnectingUsersWithMetadata> tweet5SocialProof = new HashMap<>();
     tweet5SocialProof.put(
-      favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{3, 2}), metadata2));
-
-    HashMap<Byte, ConnectingUsersWithMetadata> tweet6SocialProof = new HashMap<>();
-    tweet6SocialProof.put(
-      retweetType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{2}), metadata1));
+      FAVORITE_SOCIAL_PROOF_TYPE, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{5}), metadata1));
 
     HashMap<Byte, ConnectingUsersWithMetadata> tweet7SocialProof = new HashMap<>();
     tweet7SocialProof.put(
-      favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{1}), metadata1));
-    tweet7SocialProof.put(
-      retweetType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{3}), metadata1));
+      FAVORITE_SOCIAL_PROOF_TYPE, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{7}), metadata1));
 
     HashMap<Byte, ConnectingUsersWithMetadata> tweet8SocialProof = new HashMap<>();
     tweet8SocialProof.put(
-      favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{4}), metadata1));
+      FAVORITE_SOCIAL_PROOF_TYPE, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{9, 8}), metadata2));
 
     HashMap<Byte, ConnectingUsersWithMetadata> tweet9SocialProof = new HashMap<>();
     tweet9SocialProof.put(
-      favoriteType, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{4, 3}), metadata2));
+      FAVORITE_SOCIAL_PROOF_TYPE, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{10, 9}), metadata2));
+
+    HashMap<Byte, ConnectingUsersWithMetadata> tweet10SocialProof = new HashMap<>();
+    tweet10SocialProof.put(
+      FAVORITE_SOCIAL_PROOF_TYPE, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{10}), metadata1));
+    tweet10SocialProof.put(
+      RETWEET_SOCIAL_PROOF_TYPE, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{11}), metadata1));
+
+    HashMap<Byte, ConnectingUsersWithMetadata> tweet11SocialProof = new HashMap<>();
+    tweet11SocialProof.put(
+      RETWEET_SOCIAL_PROOF_TYPE, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{11}), metadata1));
+
+    HashMap<Byte, ConnectingUsersWithMetadata> tweet12SocialProof = new HashMap<>();
+    tweet12SocialProof.put(
+      RETWEET_SOCIAL_PROOF_TYPE, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{12}), metadata1));
+
+    HashMap<Byte, ConnectingUsersWithMetadata> tweet13SocialProof = new HashMap<>();
+    tweet13SocialProof.put(
+      FAVORITE_SOCIAL_PROOF_TYPE, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{13}), metadata1));
+    tweet13SocialProof.put(
+      RETWEET_SOCIAL_PROOF_TYPE, new ConnectingUsersWithMetadata(new LongArrayList(new long[]{14}), metadata1));
 
     List<RecommendationInfo> topSecondDegreeByCountResults =
       Lists.newArrayList(response.getRankedRecommendations());
     List<RecommendationInfo> expectedResults = new ArrayList<>();
 
-    expectedResults.add(new TweetRecommendationInfo(9, 12, tweet9SocialProof));
-    expectedResults.add(new TweetRecommendationInfo(5, 8, tweet5SocialProof));
-    expectedResults.add(new TweetRecommendationInfo(8, 7, tweet8SocialProof));
-    expectedResults.add(new TweetRecommendationInfo(7, 6, tweet7SocialProof));
-    expectedResults.add(new TweetRecommendationInfo(6, 3, tweet6SocialProof));
-    expectedResults.add(new TweetRecommendationInfo(3, 1, tweet3SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(13, 13+14, tweet13SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(10, 10+11, tweet10SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(9, 9+10, tweet9SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(8, 8+9, tweet8SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(12, 12, tweet12SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(11, 11, tweet11SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(7, 7, tweet7SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(5, 5, tweet5SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(2, 2, tweet2SocialProof));
+    expectedResults.add(new TweetRecommendationInfo(1, 1, tweet1SocialProof));
 
     assertEquals(expectedResults, topSecondDegreeByCountResults);
   }

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/filter/TweetAuthorFilterTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/filter/TweetAuthorFilterTest.java
@@ -50,17 +50,17 @@ public class TweetAuthorFilterTest {
             2.0,
             100,
             2,
-            new MockEdgeTypeMask((byte)RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE),
+            new MockEdgeTypeMask(RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE),
             new NullStatsReceiver());
     int[][] dummyNodeMetadata = new int[][]{};
 
-    leftIndexedBipartiteGraph.addEdge(1, 10, (byte)RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE,
+    leftIndexedBipartiteGraph.addEdge(1, 10, RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE,
         0L, dummyNodeMetadata, dummyNodeMetadata);
-    leftIndexedBipartiteGraph.addEdge(2, 20, (byte)RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE,
+    leftIndexedBipartiteGraph.addEdge(2, 20, RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE,
         0L, dummyNodeMetadata, dummyNodeMetadata);
-    leftIndexedBipartiteGraph.addEdge(3, 30, (byte)RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE,
+    leftIndexedBipartiteGraph.addEdge(3, 30, RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE,
         0L, dummyNodeMetadata, dummyNodeMetadata);
-    leftIndexedBipartiteGraph.addEdge(4, 40, (byte)RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE,
+    leftIndexedBipartiteGraph.addEdge(4, 40, RecommendationRequest.AUTHOR_SOCIAL_PROOF_TYPE,
         0L, dummyNodeMetadata, dummyNodeMetadata);
     return leftIndexedBipartiteGraph;
   }

--- a/graphjet-demo/pom.xml
+++ b/graphjet-demo/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.1.12-SNAPSHOT</version>
+    <version>1.1.13-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-demo</artifactId>
-  <version>1.1.12-SNAPSHOT</version>
+  <version>1.1.13-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Demo</name>
   <description>GraphJet is a real-time graph processing library: demo of core graph library</description>
@@ -26,12 +26,12 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.1.12-SNAPSHOT</version>
+      <version>1.1.13-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-adapters</artifactId>
-      <version>1.1.12-SNAPSHOT</version>
+      <version>1.1.13-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet</artifactId>
-  <version>1.1.12-SNAPSHOT</version>
+  <version>1.1.13-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>graphjet</name>


### PR DESCRIPTION
Background:
In the previous pull request I added the functionality to index unfavorite edges, so they can be used to "remove" the corresponding favorite edges. The core idea is that, for each tweet (nodeInfo), check both favorite edges and unfavorite edges, find intersection, remove the intersection, and lastly remove the remainder unfavorite edges. The end result will appear as if unfavorited edges are removed.

Problem:
I neglected a corner case where favorite edges == null and unfavorite edges != null. This allowed the call path to skip the entire unfavorite check, and unfav social proofs will not be checked or removed. This pull request covers that corner case, and added tests to cover it.

Also I moved the fave and unfav edge type definitions to RecommendationRequest.java, where most of the constants are already defined, to reduce duplication.