### PR TITLE
Add unfavorite edge processing in hashtag/url path

### DIFF
--- a/graphjet-adapters/pom.xml
+++ b/graphjet-adapters/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.1.13-SNAPSHOT</version>
+    <version>1.1.14-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-adapters</artifactId>
-  <version>1.1.13-SNAPSHOT</version>
+  <version>1.1.14-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Adapters</name>
   <description>GraphJet is a real-time graph processing library: adapters for other graph systems</description>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.1.13-SNAPSHOT</version>
+      <version>1.1.14-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>

--- a/graphjet-core/pom.xml
+++ b/graphjet-core/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.1.13-SNAPSHOT</version>
+    <version>1.1.14-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-core</artifactId>
-  <version>1.1.13-SNAPSHOT</version>
+  <version>1.1.14-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Core</name>
   <description>GraphJet is a real-time graph processing library: core graph library and recommendation algorithms</description>

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/GeneratorHelper.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/GeneratorHelper.java
@@ -147,7 +147,7 @@ public final class GeneratorHelper {
   }
 
   /**
-   * Given a nodeInfo
+   * Given a nodeInfo, check whether this nodeInfo supports unfavorite edges.
    */
   public static boolean isUnfavoriteTypeSupported(NodeInfo nodeInfo) {
     return UNFAVORITE_SOCIAL_PROOF_TYPE < nodeInfo.getSocialProofs().length;

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/GeneratorHelper.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/GeneratorHelper.java
@@ -30,6 +30,9 @@ import com.twitter.graphjet.hashing.SmallArrayBasedLongToDoubleMap;
 
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 
+import static com.twitter.graphjet.algorithms.RecommendationRequest.FAVORITE_SOCIAL_PROOF_TYPE;
+import static com.twitter.graphjet.algorithms.RecommendationRequest.UNFAVORITE_SOCIAL_PROOF_TYPE;
+
 /**
  * Shared utility functions among RecsGenerators.
  */
@@ -127,6 +130,77 @@ public final class GeneratorHelper {
         return false;
       }
     }
+    return true;
+  }
+
+  /**
+   * Given a nodeInfo, check all social proofs stored and determine if it still has
+   * valid, non-empty social proofs.
+   */
+  public static boolean nodeInfoHasValidSocialProofs(NodeInfo nodeInfo) {
+    for (SmallArrayBasedLongToDoubleMap socialProof: nodeInfo.getSocialProofs()) {
+      if (socialProof != null && socialProof.size() != 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Given a nodeInfo
+   */
+  public static boolean isUnfavoriteTypeSupported(NodeInfo nodeInfo) {
+    return UNFAVORITE_SOCIAL_PROOF_TYPE < nodeInfo.getSocialProofs().length;
+  }
+
+  /**
+   * Given a nodeInfo containing the collection of all social proofs on a tweet, remove the
+   * Favorite social proofs that also have Unfavorite counterparts, and deduct the weight of the
+   * nodeInfo accordingly. The Unfavorite social proofs will always be reset to null.
+   *
+   * @return true if the nodInfo has been modified, i.e. have Unfavorited removed, false otherwise.
+   */
+  public static boolean removeUnfavoriteSocialProofs(NodeInfo nodeInfo) {
+    if (!isUnfavoriteTypeSupported(nodeInfo)) {
+      return false;
+    }
+
+    SmallArrayBasedLongToDoubleMap[] socialProofs = nodeInfo.getSocialProofs();
+    SmallArrayBasedLongToDoubleMap unfavSocialProofs = socialProofs[UNFAVORITE_SOCIAL_PROOF_TYPE];
+    SmallArrayBasedLongToDoubleMap favSocialProofs = socialProofs[FAVORITE_SOCIAL_PROOF_TYPE];
+
+    if (unfavSocialProofs == null) {
+      return false;
+    }
+
+    // Always remove unfavorite social proofs, as they are only meant for internal processing and
+    // not to be returned to the caller.
+    double unfavWeightToRemove = 0;
+    for (int i = 0; i < unfavSocialProofs.size(); i++) {
+      unfavWeightToRemove += unfavSocialProofs.values()[i];
+    }
+    nodeInfo.setWeight(nodeInfo.getWeight() - unfavWeightToRemove);
+    socialProofs[UNFAVORITE_SOCIAL_PROOF_TYPE] = null;
+
+    // Remove favorite social proofs that were unfavorited and the corresponding weights
+    if (favSocialProofs != null) {
+      int favWeightToRemove = 0;
+      SmallArrayBasedLongToDoubleMap newFavSocialProofs = new SmallArrayBasedLongToDoubleMap();
+      for (int i = 0; i < favSocialProofs.size(); i++) {
+        long favUser = favSocialProofs.keys()[i];
+        double favWeight = favSocialProofs.values()[i];
+
+        if (unfavSocialProofs.contains(favUser)) {
+          favWeightToRemove += favWeight;
+        } else {
+          newFavSocialProofs.put(favUser, favWeight, favSocialProofs.metadata()[i]);
+        }
+      }
+      // Add the filtered Favorite social proofs
+      nodeInfo.setWeight(nodeInfo.getWeight() - favWeightToRemove);
+      socialProofs[FAVORITE_SOCIAL_PROOF_TYPE] = (newFavSocialProofs.size() != 0) ? newFavSocialProofs : null;
+    }
+
     return true;
   }
 }

--- a/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
+++ b/graphjet-core/src/main/java/com/twitter/graphjet/algorithms/counting/tweetfeature/TopSecondDegreeByCountTweetRecsGenerator.java
@@ -40,80 +40,8 @@ import static com.twitter.graphjet.algorithms.RecommendationRequest.UNFAVORITE_S
 
 public final class TopSecondDegreeByCountTweetRecsGenerator {
   private static final TweetIDMask TWEET_ID_MASK = new TweetIDMask();
-  private static final byte FavoriteSocialProofType = 1;
-  private static final byte UnfavoriteSocialProofType = 8;
 
   private TopSecondDegreeByCountTweetRecsGenerator() {
-  }
-
-  private static boolean isUnfavoriteTypeSupported(NodeInfo nodeInfo) {
-    return UnfavoriteSocialProofType < nodeInfo.getSocialProofs().length;
-  }
-
-
-  /**
-   * Given a nodeInfo containing the collection of all social proofs on a tweet, remove the
-   * Favorite social proofs that also have Unfavorite counterparts, and deduct the weight of the
-   * nodeInfo accordingly. The Unfavorite social proofs will always be reset to null.
-   *
-   * @return true if the nodInfo has been modified, i.e. have Unfavorited removed, false otherwise.
-   */
-  private static boolean removeUnfavoriteSocialProofs(NodeInfo nodeInfo) {
-    if (!isUnfavoriteTypeSupported(nodeInfo)) {
-      return false;
-    }
-
-    SmallArrayBasedLongToDoubleMap[] socialProofs = nodeInfo.getSocialProofs();
-    SmallArrayBasedLongToDoubleMap unfavSocialProofs = socialProofs[UNFAVORITE_SOCIAL_PROOF_TYPE];
-    SmallArrayBasedLongToDoubleMap favSocialProofs = socialProofs[FAVORITE_SOCIAL_PROOF_TYPE];
-
-    if (unfavSocialProofs == null) {
-      return false;
-    }
-
-    // Always remove unfavorite social proofs, as they are only meant for internal processing and
-    // not to be returned to the caller.
-    double unfavWeightToRemove = 0;
-    for (int i = 0; i < unfavSocialProofs.size(); i++) {
-      unfavWeightToRemove += unfavSocialProofs.values()[i];
-    }
-    nodeInfo.setWeight(nodeInfo.getWeight() - unfavWeightToRemove);
-    socialProofs[UNFAVORITE_SOCIAL_PROOF_TYPE] = null;
-
-    // Remove favorite social proofs that were unfavorited and the corresponding weights
-    if (favSocialProofs != null) {
-      int favWeightToRemove = 0;
-      SmallArrayBasedLongToDoubleMap newFavSocialProofs = new SmallArrayBasedLongToDoubleMap();
-      for (int i = 0; i < favSocialProofs.size(); i++) {
-        long favUser = favSocialProofs.keys()[i];
-        double favWeight = favSocialProofs.values()[i];
-
-        if (unfavSocialProofs.contains(favUser)) {
-          favWeightToRemove += favWeight;
-        } else {
-          newFavSocialProofs.put(favUser, favWeight, favSocialProofs.metadata()[i]);
-        }
-      }
-      // Add the filtered Favorite social proofs
-      nodeInfo.setWeight(nodeInfo.getWeight() - favWeightToRemove);
-      socialProofs[FAVORITE_SOCIAL_PROOF_TYPE] = (newFavSocialProofs.size() != 0) ? newFavSocialProofs : null;
-    }
-
-    return true;
-  }
-
-
-  /**
-   * Given a nodeInfo, check all social proofs stored and determine if it still has
-   * valid, non-empty social proofs.
-   */
-  private static boolean nodeInfoHasValidSocialProofs(NodeInfo nodeInfo) {
-    for ( SmallArrayBasedLongToDoubleMap socialProof: nodeInfo.getSocialProofs()) {
-      if (socialProof != null && socialProof.size() != 0) {
-        return true;
-      }
-    }
-    return false;
   }
 
   /**
@@ -135,8 +63,8 @@ public final class TopSecondDegreeByCountTweetRecsGenerator {
     // handling specific rules of tweet recommendations
     for (NodeInfo nodeInfo : nodeInfoList) {
       // Remove unfavorited edges, and discard the nodeInfo if it no longer has social proofs
-      boolean isNodeModified = removeUnfavoriteSocialProofs(nodeInfo);
-      if (isNodeModified && !nodeInfoHasValidSocialProofs(nodeInfo)) {
+      boolean isNodeModified = GeneratorHelper.removeUnfavoriteSocialProofs(nodeInfo);
+      if (isNodeModified && !GeneratorHelper.nodeInfoHasValidSocialProofs(nodeInfo)) {
         continue;
       }
 

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/BipartiteGraphTestHelper.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/BipartiteGraphTestHelper.java
@@ -254,67 +254,67 @@ public final class BipartiteGraphTestHelper {
         new HigherBitsEdgeTypeMask(),
         new NullStatsReceiver()
       );
-    int[][] nodeMeta = new int[][]{};
+    int[][] emptyMeta = new int[][]{};
 
     // Only Favorite
-    nodeMetadataGraph.addEdge(user1, tweet1, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet1, favoriteEdge, 0L, emptyMeta, new int[][]{{1}});
 
     // Only Retweet
-    nodeMetadataGraph.addEdge(user2, tweet2, retweetEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user2, tweet2, retweetEdge, 0L, emptyMeta, new int[][]{{2}});
 
     // Only Unfavorite
     // invalid node
-    nodeMetadataGraph.addEdge(user1, tweet3, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user2, tweet3, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet3, unfavoriteEdge, 0L, emptyMeta, emptyMeta);
+    nodeMetadataGraph.addEdge(user2, tweet3, unfavoriteEdge, 0L, emptyMeta, emptyMeta);
 
     // Favorite & Unfavorite
     // invalid node
-    nodeMetadataGraph.addEdge(user1, tweet4, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user1, tweet4, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet4, favoriteEdge, 0L, emptyMeta, emptyMeta);
+    nodeMetadataGraph.addEdge(user1, tweet4, unfavoriteEdge, 0L, emptyMeta, emptyMeta);
 
-    nodeMetadataGraph.addEdge(user5, tweet5, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user2, tweet5, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user5, tweet5, favoriteEdge, 0L, emptyMeta, new int[][]{{5}});
+    nodeMetadataGraph.addEdge(user2, tweet5, unfavoriteEdge, 0L, emptyMeta, new int[][]{{5}});
 
     // invalid node
-    nodeMetadataGraph.addEdge(user1, tweet6, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user1, tweet6, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user1, tweet6, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet6, favoriteEdge, 0L, emptyMeta, emptyMeta);
+    nodeMetadataGraph.addEdge(user1, tweet6, unfavoriteEdge, 0L, emptyMeta, emptyMeta);
+    nodeMetadataGraph.addEdge(user1, tweet6, favoriteEdge, 0L, emptyMeta, emptyMeta);
 
-    nodeMetadataGraph.addEdge(user7, tweet7, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user3, tweet7, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user4, tweet7, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user7, tweet7, favoriteEdge, 0L, emptyMeta, new int[][]{{7}});
+    nodeMetadataGraph.addEdge(user3, tweet7, unfavoriteEdge, 0L, emptyMeta, new int[][]{{7}});
+    nodeMetadataGraph.addEdge(user4, tweet7, unfavoriteEdge, 0L, emptyMeta, new int[][]{{7}});
 
-    nodeMetadataGraph.addEdge(user1, tweet8, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user1, tweet8, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user8, tweet8, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user9, tweet8, favoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet8, favoriteEdge, 0L, emptyMeta, new int[][]{{8}});
+    nodeMetadataGraph.addEdge(user1, tweet8, unfavoriteEdge, 0L, emptyMeta, new int[][]{{8}});
+    nodeMetadataGraph.addEdge(user8, tweet8, favoriteEdge, 0L, emptyMeta, new int[][]{{8}});
+    nodeMetadataGraph.addEdge(user9, tweet8, favoriteEdge, 0L, emptyMeta, new int[][]{{8}});
 
-    nodeMetadataGraph.addEdge(user1, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user2, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user9, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user10, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user5, tweet9, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user1, tweet9, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user2, tweet9, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user5, tweet9, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user1, tweet9, favoriteEdge, 0L, emptyMeta, new int[][]{{9}});
+    nodeMetadataGraph.addEdge(user2, tweet9, favoriteEdge, 0L, emptyMeta, new int[][]{{9}});
+    nodeMetadataGraph.addEdge(user9, tweet9, favoriteEdge, 0L, emptyMeta, new int[][]{{9}});
+    nodeMetadataGraph.addEdge(user10, tweet9, favoriteEdge, 0L, emptyMeta, new int[][]{{9}});
+    nodeMetadataGraph.addEdge(user5, tweet9, favoriteEdge, 0L, emptyMeta, new int[][]{{9}});
+    nodeMetadataGraph.addEdge(user1, tweet9, unfavoriteEdge, 0L, emptyMeta, new int[][]{{9}});
+    nodeMetadataGraph.addEdge(user2, tweet9, unfavoriteEdge, 0L, emptyMeta, new int[][]{{9}});
+    nodeMetadataGraph.addEdge(user5, tweet9, unfavoriteEdge, 0L, emptyMeta, new int[][]{{9}});
 
     // Favorite & Retweet
-    nodeMetadataGraph.addEdge(user10, tweet10, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user11, tweet10, retweetEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user10, tweet10, favoriteEdge, 0L, emptyMeta, new int[][]{{10}});
+    nodeMetadataGraph.addEdge(user11, tweet10, retweetEdge, 0L, emptyMeta, new int[][]{{10}});
 
     // Unfavorite & Retweet
-    nodeMetadataGraph.addEdge(user2, tweet11, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user11, tweet11, retweetEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user2, tweet11, unfavoriteEdge, 0L, emptyMeta, new int[][]{{11}});
+    nodeMetadataGraph.addEdge(user11, tweet11, retweetEdge, 0L, emptyMeta, new int[][]{{11}});
 
     // Favorite, Unfavorite, and Retweet
-    nodeMetadataGraph.addEdge(user12, tweet12, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user12, tweet12, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user12, tweet12, retweetEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user3, tweet12, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user12, tweet12, favoriteEdge, 0L, emptyMeta, new int[][]{{12}});
+    nodeMetadataGraph.addEdge(user12, tweet12, unfavoriteEdge, 0L, emptyMeta, new int[][]{{12}});
+    nodeMetadataGraph.addEdge(user12, tweet12, retweetEdge, 0L, emptyMeta, new int[][]{{12}});
+    nodeMetadataGraph.addEdge(user3, tweet12, unfavoriteEdge, 0L, emptyMeta, new int[][]{{12}});
 
-    nodeMetadataGraph.addEdge(user13, tweet13, favoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user14, tweet13, unfavoriteEdge, 0L, nodeMeta, nodeMeta);
-    nodeMetadataGraph.addEdge(user14, tweet13, retweetEdge, 0L, nodeMeta, nodeMeta);
+    nodeMetadataGraph.addEdge(user13, tweet13, favoriteEdge, 0L, emptyMeta, new int[][]{{13}});
+    nodeMetadataGraph.addEdge(user14, tweet13, unfavoriteEdge, 0L, emptyMeta, new int[][]{{13}});
+    nodeMetadataGraph.addEdge(user14, tweet13, retweetEdge, 0L, emptyMeta, new int[][]{{13}});
 
     return nodeMetadataGraph;
   }

--- a/graphjet-demo/pom.xml
+++ b/graphjet-demo/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.twitter</groupId>
     <artifactId>graphjet</artifactId>
-    <version>1.1.13-SNAPSHOT</version>
+    <version>1.1.14-SNAPSHOT</version>
   </parent>
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet-demo</artifactId>
-  <version>1.1.13-SNAPSHOT</version>
+  <version>1.1.14-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>GraphJet Demo</name>
   <description>GraphJet is a real-time graph processing library: demo of core graph library</description>
@@ -26,12 +26,12 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-core</artifactId>
-      <version>1.1.13-SNAPSHOT</version>
+      <version>1.1.14-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>graphjet-adapters</artifactId>
-      <version>1.1.13-SNAPSHOT</version>
+      <version>1.1.14-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.twitter</groupId>
   <artifactId>graphjet</artifactId>
-  <version>1.1.13-SNAPSHOT</version>
+  <version>1.1.14-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>graphjet</name>


### PR DESCRIPTION
This is yet another follow up change set to add unfavorite edge indexing in GraphJet, this time we add this functionality for Hashtag/Urls. 
In the tweet counting algorithms, tweet, hashtag, and urls all share the same graph traversal logic, i.e. they all collect and index unfavorite edges. However, during candidate generation, tweet and hashtag/url have a separate code paths. We previously patched up the tweet code path, but neglected hashtag/urls.
This request consolidates the unfavorite logic in one place, i.e. GeneratorHelper.java. Also added new tests to cover hashtag/urls. 