### PR TITLE
Bump jetty versions to patch vulnerability

### DIFF
--- a/graphjet-demo/pom.xml
+++ b/graphjet-demo/pom.xml
@@ -46,12 +46,12 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.3.11.v20160721</version>
+      <version>9.3.24.v20180605</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.3.11.v20160721</version>
+      <version>9.3.24.v20180605</version>
     </dependency>
     <dependency>
       <groupId>args4j</groupId>


### PR DESCRIPTION
Bump Jetty version to patch a vulnerability. Details here
https://nvd.nist.gov/vuln/detail/CVE-2017-7657