### PR TITLE
patch another security bug in jetty

### DIFF
--- a/graphjet-demo/pom.xml
+++ b/graphjet-demo/pom.xml
@@ -46,12 +46,12 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.12.v20180830</version>
+      <version>9.4.17.v20190418</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.12.v20180830</version>
+      <version>9.4.17.v20190418</version>
     </dependency>
     <dependency>
       <groupId>args4j</groupId>


### PR DESCRIPTION
Received another security vulnerability alert regarding jetty versions (CVE-2019-10247). Patching to a newer version