### PR TITLE
Fix flaky

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  run_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 8
+
+      - name: Run Test
+        run: mvn -pl graphjet-core test -Dtest='com.twitter.graphjet.algorithms.salsa.SalsaTest#testSalsaWithRandomGraph'
+                
+  run_test_with_nondex:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: 8
+        
+    - name: Run Test w nondex
+      run: mvn -pl graphjet-core edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest='com.twitter.graphjet.algorithms.salsa.SalsaTest#testSalsaWithRandomGraph'
+      

--- a/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/salsa/SalsaTest.java
+++ b/graphjet-core/src/test/java/com/twitter/graphjet/algorithms/salsa/SalsaTest.java
@@ -213,43 +213,44 @@ public class SalsaTest {
 
     int maxUserId = 1000;
 
-    final SalsaStats expectedSalsaStats = new SalsaStats(1, 64, 998, 21050, 1, 227, 64);
+    final SalsaStats expectedSalsaStats = new SalsaStats(1, 62, 999, 21124, 1, 231, 62);
 
-    LongList metadata7 = new LongArrayList(new long[]{0, 0, 0, 0, 0, 0, 0});
-    LongList metadata10 = new LongArrayList(new long[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+    LongList metadata6 = new LongArrayList(new long[]{0, 0, 0, 0, 0, 0});
+    LongList metadata9 = new LongArrayList(new long[]{0, 0, 0, 0, 0, 0, 0, 0, 0});
+    LongList metadata13 = new LongArrayList(new long[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
     ArrayList<HashMap<Byte, ConnectingUsersWithMetadata>> socialProof = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
       socialProof.add(new HashMap<>());
     }
     socialProof.get(0).put(
       (byte) 0, new ConnectingUsersWithMetadata(
-        new LongArrayList(new long[]{718, 889, 109, 164, 207, 767, 302, 888, 453, 738}),
-        metadata10
+        new LongArrayList(new long[]{917, 343, 386, 769, 125, 306, 420, 801, 858, 615, 105, 295, 358}),
+        metadata13
       )
     );
     socialProof.get(1).put(
       (byte) 0, new ConnectingUsersWithMetadata(
-        new LongArrayList(new long[]{47, 96, 499, 306, 396, 805, 351, 875, 308, 186}),
-        metadata10
+        new LongArrayList(new long[]{783, 607, 879, 718, 2, 586, 959, 893, 62}),
+        metadata9
       )
     );
     socialProof.get(2).put(
       (byte) 0, new ConnectingUsersWithMetadata(
-        new LongArrayList(new long[]{623, 880, 550, 363, 886, 156, 130}),
-        metadata7
+        new LongArrayList(new long[]{440, 971, 623, 767, 875, 157}),
+        metadata6
       )
     );
 
     final List<RecommendationInfo> expectedTopResults = new ArrayList<RecommendationInfo>();
-    expectedTopResults.add(new TweetRecommendationInfo(735, 0.0010926365795724466,
+    expectedTopResults.add(new TweetRecommendationInfo(827, 0.0013255065328536262,
       socialProof.get(0)));
-    expectedTopResults.add(new TweetRecommendationInfo(119, 0.0010451306413301663,
+    expectedTopResults.add(new TweetRecommendationInfo(682, 0.0011834879757621662,
       socialProof.get(1)));
-    expectedTopResults.add(new TweetRecommendationInfo(70, 0.0010451306413301663,
+    expectedTopResults.add(new TweetRecommendationInfo(691, 0.0011361484567316796,
       socialProof.get(2)));
 
-    Set<Long> sourceIdList = Sets.newHashSetWithExpectedSize(maxNumLeftNodes);
-    Set<Long> destinationIds = Sets.newHashSetWithExpectedSize(leftDegree);
+    Set<Long> sourceIdList = Sets.newLinkedHashSetWithExpectedSize(maxNumLeftNodes);
+    Set<Long> destinationIds = Sets.newLinkedHashSetWithExpectedSize(leftDegree);
 
     smallLeftRegularBipartiteGraph.reset();
     long userId = random.nextInt(maxUserId);


### PR DESCRIPTION
### Flaky Test testSalsaWithRandomGraph
The **`SalsaTest.testSalsaWithRandomGraph`** is a test that aims to generate user recommendations using the SALSA algorithm on a Bipartite graph. However, the test was found to be flaky due to the inconsistent ordering of elements in the HashSets, used to construct the graph. 
_As `HashSet` does not maintain the order of elements, depending on the HashSet implementation, different _**Java versions**_ result in different orderings, resulting in **_different bipartite graphs and making tests flaky_**._

___
### FIX
To fix this issue I have changed the test to use a `LinkedHashSet` rather than a regular `HashSet `to maintain the order of elements consistently across different platforms and Java versions (lines 252, 253). `LinkedHashSet`, unlike `HashSet`, maintains the order of insertion of elements, which is essential for generating a **_predictable Bipartite graph_**. This is because the graph's structure is determined by the order of edges connecting similar users and similar followings, which in turn is determined by the order of elements in the **_sourceIdList and destinationIds_** sets.

As the test used hardcoded values to compare the expected results with the actual results, with the change to a LinkedHashSet, I needed to update these values to reflect the new ordering of elements. Therefore, I carefully analyzed the graph generated by the updated test and fixed the expected results accordingly to ensure that they matched the actual results.

__________

The test passed successfully with nondex runs.
